### PR TITLE
feat(server): add Client class for per-connection state management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CPP = c++
 
 FLAGS = -Wall -Werror -Wextra -std=c++98
 
-SRCS = src/general/main.cpp src/server/Server.cpp
+SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/client/Client.hpp
+++ b/includes/client/Client.hpp
@@ -1,0 +1,38 @@
+#ifndef CLIENT_HPP
+#define CLIENT_HPP
+
+#include <string>
+
+class Client
+{
+private:
+    int _fd;
+    std::string _nickname;
+    std::string _username;
+    std::string _inputBuffer;
+    bool    _isAuthenticated;
+public:
+    Client(int fd);
+    ~Client();
+    
+    // Getters
+    int getFd() const;
+    const std::string& getNickname() const;
+    const std::string& getUsername() const;
+    const std::string& getInputBuffer() const;
+    bool    getIsAuthenticated() const;
+
+    // Setters
+    void    setNickname(const std::string& nickname);
+    void    setUsername(const std::string& username);
+    void    setIsAuthenticated(bool state);
+
+    // Public methods
+    void    appendBuffer(const std::string& append);
+    void    clearBuffer();
+};
+
+
+
+
+#endif

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -16,7 +16,7 @@ private:
     std::string _password;
     int _serverSocketFd;
     bool    _running;
-    std::map<int, Client*>  _clients; 
+    std::map<int, Client>  _clients; 
     std::vector<pollfd> _pollFds;
 
     // Server private methods

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1,0 +1,49 @@
+#include "../../includes/client/Client.hpp"
+#include <unistd.h>
+
+Client::Client(int fd): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _isAuthenticated(false) {}
+
+Client::~Client() {
+    if (_fd >= 0)
+        close(_fd);
+}
+
+int Client::getFd() const {
+    return (_fd);
+}
+
+const std::string& Client::getNickname() const {
+    return (_nickname);
+}
+
+const std::string& Client::getUsername() const {
+    return (_username);
+}
+
+const std::string& Client::getInputBuffer() const {
+    return (_inputBuffer);
+}
+
+bool    Client::getIsAuthenticated() const {
+    return (_isAuthenticated);
+}
+
+void    Client::setNickname(const std::string& nickname) {
+    _nickname = nickname;
+}
+
+void    Client::setUsername(const std::string& username) {
+    _username = username;
+}
+
+void    Client::setIsAuthenticated(bool state) {
+    _isAuthenticated = state;
+}
+
+void    Client::appendBuffer(const std::string& append) {
+    _inputBuffer += append;
+}
+
+void    Client::clearBuffer() {
+    _inputBuffer.clear();
+}

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -1,4 +1,5 @@
 #include "../../includes/server/Server.hpp"
+#include "../../includes/client/Client.hpp"
 #include <sys/socket.h>
 #include <stdexcept>
 #include <unistd.h>
@@ -93,7 +94,7 @@ void    Server::runPollLoop() {
                     // Accept new client
                     int clientFd = accept(_serverSocketFd, NULL, NULL);
                     if (clientFd >= 0)
-                        close(clientFd);
+                        _clients.insert(std::make_pair(clientFd, Client(clientFd)));
                 }
                 else
                 {


### PR DESCRIPTION
Introduce Client abstraction to encapsulate:
- socket file descriptor
- nickname and username
- input buffering
- authentication state

Client objects are instantiated upon new connections and managed via std::map<int, Client>.

Compiles with -Wall -Wextra -Werror.
Valgrind reports no leaks.

Closes #5 