### PR TITLE
feat(server): handle new client connections with accept()

### DIFF
--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -28,6 +28,7 @@ private:
     void    setupServerPoll();
     void    setupPolling();
     void    runPollLoop();
+    void    handleNewConnection();
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -3,10 +3,7 @@
 
 Client::Client(int fd): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _isAuthenticated(false) {}
 
-Client::~Client() {
-    if (_fd >= 0)
-        close(_fd);
-}
+Client::~Client() {}
 
 int Client::getFd() const {
     return (_fd);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <arpa/inet.h>
 #include <iostream>
+#include <cerrno>
 
 Server::Server(int port, const std::string &password) {
     _port = port;
@@ -77,13 +78,36 @@ void    Server::setupPolling() {
     setupServerPoll();
 }
 
+void    Server::handleNewConnection() {
+    while (true)
+    {
+        int clientFd = accept(_serverSocketFd, NULL, NULL);
+        if (clientFd < 0)
+        {
+            if (errno == EWOULDBLOCK || errno == EAGAIN)
+                break;
+            else
+                throw std::runtime_error("Accept execution failed");
+        }
+        fcntl(clientFd, F_SETFL, O_NONBLOCK);
+        _clients.insert(std::make_pair(clientFd, Client(clientFd)));
+        pollfd clientPollFd;
+        clientPollFd.fd = clientFd;
+        clientPollFd.events = POLLIN;
+        clientPollFd.revents = 0;
+        _pollFds.push_back(clientPollFd);
+
+        std::cout << "New client Connected: FD " << clientFd << std::endl;
+    }
+}
+
 void    Server::runPollLoop() {
     while (true)
     {
         int ready = poll(_pollFds.data(),_pollFds.size(), -1);
         if (ready < 0)
             throw std::runtime_error("Poll execution failed");
-        for (size_t i = 0; i < _pollFds.size(); i++)
+        for (size_t i = 0; i < _pollFds.size() && ready > 0; i++)
         {
             if (_pollFds[i].revents == 0)
                 continue;
@@ -92,9 +116,7 @@ void    Server::runPollLoop() {
                 if (_pollFds[i].fd == _serverSocketFd)
                 {
                     // Accept new client
-                    int clientFd = accept(_serverSocketFd, NULL, NULL);
-                    if (clientFd >= 0)
-                        _clients.insert(std::make_pair(clientFd, Client(clientFd)));
+                    handleNewConnection();
                 }
                 else
                 {


### PR DESCRIPTION
- Call accept() on server socket when POLLIN is triggered
- Create Client instance for each new connection
- Set client sockets to non-blocking mode
- Add client file descriptor to poll vector
- Store Client objects in std::map<int, Client>
- Handle EWOULDBLOCK/EAGAIN correctly

Supports multiple simultaneous client connections. No crashes observed during manual testing (3+ clients). Valgrind reports no memory leaks.