### PR TITLE
feat(parser): implement client buffering and IRC message extraction

### DIFF
--- a/includes/client/Client.hpp
+++ b/includes/client/Client.hpp
@@ -19,7 +19,7 @@ public:
     int getFd() const;
     const std::string& getNickname() const;
     const std::string& getUsername() const;
-    const std::string& getInputBuffer() const;
+    std::string& getInputBuffer();
     bool    getIsAuthenticated() const;
 
     // Setters

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -29,6 +29,9 @@ private:
     void    setupPolling();
     void    runPollLoop();
     void    handleNewConnection();
+    void    handleClientData(int clientFd);
+    void    processClientBuffer(Client &client);
+    void    removeClient(int clientFd);
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -17,7 +17,7 @@ const std::string& Client::getUsername() const {
     return (_username);
 }
 
-const std::string& Client::getInputBuffer() const {
+std::string& Client::getInputBuffer() {
     return (_inputBuffer);
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -101,6 +101,57 @@ void    Server::handleNewConnection() {
     }
 }
 
+void    Server::processClientBuffer(Client &client)
+{
+    std::string &buf = client.getInputBuffer();
+    size_t pos;
+
+    while ((pos = buf.find("\n")) != std::string::npos)
+    {
+        std::string message = buf.substr(0, pos);
+        buf.erase(0, pos + 1);
+        std::cout << "Received command: " << message << std::endl;
+    }
+}
+
+void    Server::removeClient(int clientFd)
+{
+    close(clientFd);
+    _clients.erase(clientFd);
+    for (size_t i = 0; i < _pollFds.size(); i++)
+    {
+        if (_pollFds[i].fd == clientFd)
+        {
+            _pollFds.erase(_pollFds.begin() + i);
+            break;
+        }
+    }
+}
+
+void    Server::handleClientData(int clientFd)
+{
+    char    buffer[512];
+    ssize_t bytes = recv(clientFd, buffer, sizeof(buffer), 0);
+
+    if (bytes > 0)
+        buffer[bytes] = '\0';
+    else if (bytes == 0)
+    {
+        std::cout << "Client disconnected\n";
+        removeClient(clientFd);
+        return ;
+    }
+    std::map<int, Client>::iterator it = _clients.find(clientFd);
+    if (it == _clients.end())
+    {
+        std::cerr << "Client not found!" << std::endl;
+        return ;
+    }
+    Client &client = it->second;
+    client.getInputBuffer().append(buffer, bytes);
+    processClientBuffer(client);
+}
+
 void    Server::runPollLoop() {
     while (true)
     {
@@ -120,7 +171,8 @@ void    Server::runPollLoop() {
                 }
                 else
                 {
-                    ; // Receive data from client
+                    // Receive data from client
+                    handleClientData(_pollFds[i].fd);
                 }
             }
         }


### PR DESCRIPTION
- Read incoming data from clients using recv()
- Append received data to client input buffer
- Detect complete IRC messages using CRLF (\r\n)
- Extract and process multiple commands from a single recv
- Preserve partial messages in buffer until completion

Ensures the server correctly handles fragmented packets and multiple commands arriving in a single network read.

Closes #7