### PR TITLE
feat: add _isRegistered property to Client class

### DIFF
--- a/includes/client/Client.hpp
+++ b/includes/client/Client.hpp
@@ -12,6 +12,7 @@ private:
 	std::string _realname;
     std::string _inputBuffer;
     bool    _isAuthenticated;
+	bool	_isRegistered;
 public:
     Client(int fd);
     ~Client();
@@ -23,12 +24,14 @@ public:
     const std::string& getRealname() const;
     std::string& getInputBuffer();
     bool    getIsAuthenticated() const;
+	bool	getIsRegistered() const;
 
     // Setters
     void    setNickname(const std::string& nickname);
     void    setUsername(const std::string& username);
     void    setRealname(const std::string& realname);
     void    setIsAuthenticated(bool state);
+	void	setIsRegistered(bool state);
 
     // Public methods
     void    appendBuffer(const std::string& append);

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1,7 +1,7 @@
 #include "../../includes/client/Client.hpp"
 #include <unistd.h>
 
-Client::Client(int fd): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _isAuthenticated(false) {}
+Client::Client(int fd): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _isAuthenticated(false), _isRegistered(false) {}
 
 Client::~Client() {}
 
@@ -29,6 +29,10 @@ bool    Client::getIsAuthenticated() const {
     return (_isAuthenticated);
 }
 
+bool	Client::getIsRegistered() const {
+	return (_isRegistered);
+}
+
 void    Client::setNickname(const std::string& nickname) {
     _nickname = nickname;
 }
@@ -43,6 +47,10 @@ void    Client::setRealname(const std::string& realname) {
 
 void    Client::setIsAuthenticated(bool state) {
     _isAuthenticated = state;
+}
+
+void	Client::setIsRegistered(bool state) {
+	_isRegistered = state;
 }
 
 void    Client::appendBuffer(const std::string& append) {

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -149,10 +149,9 @@ void    Server::processClientBuffer(Client &client)
 			else
 				sendMessage(client.getFd(), "421 " + client.getNickname() + " " + split_msg[0] + " :Unknown command");
 		}
-		if (client.getIsAuthenticated() && !client.getNickname().empty() 
-			&& !client.getUsername().empty() && !client.getRealname().empty())
+		if (!client.getIsRegistered() && client.getIsAuthenticated() 
+			&& !client.getNickname().empty() && !client.getUsername().empty())
 			client.setIsRegistered(true);
-
 		// TODO message if command has no parameters
     }
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -149,6 +149,11 @@ void    Server::processClientBuffer(Client &client)
 			else
 				sendMessage(client.getFd(), "421 " + client.getNickname() + " " + split_msg[0] + " :Unknown command");
 		}
+		if (client.getIsAuthenticated() && !client.getNickname().empty() 
+			&& !client.getUsername().empty() && !client.getRealname().empty())
+			client.setIsRegistered(true);
+
+		// TODO message if command has no parameters
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `_isRegistered` boolean property to Client class
- Add getter `getIsRegistered()` and setter `setIsRegistered()`
- Initialize `_isRegistered` to `false` in constructor
- Registering client in Server.cpp

## Context
This is part of issue #21 — finalizing the client registration process. This PR adds the tracking property needed to mark a client as fully registered once PASS, NICK, and USER have been correctly provided. The registration logic in Server.cpp will follow in a subsequent commit.

## Changes
- `includes/client/Client.hpp`: Added `_isRegistered` member, `getIsRegistered()`, `setIsRegistered()`
- `src/client/Client.cpp`: Implemented getter/setter, initialized in constructor
- - `src/server/Server.cpp`: Implemented Client registration logic

## Testing
- [ ] Check if Client._isRegisterd is set to true after setting NICK and USER
- [ ] Code compiles with `-Wall -Wextra -Werror`
- [ ] No memory leaks