### PR TITLE
feat(dispatcher): implement command dispatching system

### DIFF
--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -20,6 +20,8 @@ private:
     std::map<int, Client>  _clients; 
     std::vector<pollfd> _pollFds;
     std::map<std::string, Channel> _channels;
+	typedef void (Server::*CommandHandler)(Client&, const std::string&, const std::vector<std::string>&);
+	std::map<std::string, CommandHandler> _cmdMap;
 
     // Server private methods
     void    setupSocketOpts();
@@ -36,6 +38,10 @@ private:
     void    removeClient(int clientFd);
     void    sendMessage(int clientFd, const std::string &message);
     void    broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd);
+	void	initCommandMap();
+	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void	handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void	handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -8,8 +8,6 @@
 
 bool	authPass(Client &client, std::string password, std::string server_password);
 void	setClientNick(std::string nickname, Client &client);
-bool	authPass(Client &client, std::string password, std::string server_password);
-void	setClientNick(std::string nickname, Client &client);
 bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 
 #endif

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -148,19 +148,7 @@ void    Server::processClientBuffer(Client &client)
 				(this->*(it->second))(client, message, split_msg);
 			else
 				sendMessage(client.getFd(), "421 " + client.getNickname() + " " + split_msg[0] + " :Unknown command");
-			// if (split_msg[0].compare("PASS") == 0)
-			// 	if (!authPass(client, split_msg[1], _password))
-			// 		Server::removeClient(client.getFd());
-			// if (split_msg[0].compare("NICK") == 0 && isNewNick(_clients, split_msg[1]))
-			// 	setClientNick(split_msg[1], client);
-			// if (split_msg[0].compare("USER") == 0)
-			// 	setClientUsername(message, split_msg, client);
 		}
-		std::cout << client.getNickname() << std::endl;
-		std::cout << client.getUsername() << std::endl;
-		std::cout << client.getRealname() << std::endl;
-
-		// TODO message if command has no parameters
     }
 }
 
@@ -212,16 +200,14 @@ void	Server::handlePass(Client &client, const std::string &rawMsg, const std::ve
 
 void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	if (rawMsg.compare("NICK") == 0 && isNewNick(_clients, tokens[1]))
+	(void)rawMsg;
+	if (isNewNick(_clients, tokens[1]))
 		setClientNick(tokens[1], client);
-
 }
 
 void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	if (tokens[0].compare("USER") == 0)
-		setClientUsername(rawMsg, tokens, client);
-
+	setClientUsername(rawMsg, tokens, client);
 }
 
 void	Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -194,6 +194,8 @@ void    Server::broadcastToChannel(const std::string &channelName, const std::st
 void	Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	(void)rawMsg;
+	if (tokens.size() < 2)
+		return ;
 	if (!authPass(client, tokens[1], _password))
 		Server::removeClient(client.getFd());
 }
@@ -201,12 +203,16 @@ void	Server::handlePass(Client &client, const std::string &rawMsg, const std::ve
 void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	(void)rawMsg;
+	if (tokens.size() < 2)
+		return ;
 	if (isNewNick(_clients, tokens[1]))
 		setClientNick(tokens[1], client);
 }
 
 void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	if (tokens.size() < 2)
+		return ;
 	setClientUsername(rawMsg, tokens, client);
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -141,15 +141,20 @@ void    Server::processClientBuffer(Client &client)
         buf.erase(0, pos + 1);
 		std::vector<std::string> split_msg = split(message);
         std::cout << "Received command: " << message << std::endl;
-		if (split_msg.size() > 1)
+		if (!split_msg.empty())
 		{
-			if (split_msg[0].compare("PASS") == 0)
-				if (!authPass(client, split_msg[1], _password))
-					Server::removeClient(client.getFd());
-			if (split_msg[0].compare("NICK") == 0 && isNewNick(_clients, split_msg[1]))
-				setClientNick(split_msg[1], client);
-			if (split_msg[0].compare("USER") == 0)
-				setClientUsername(message, split_msg, client);
+			std::map<std::string, CommandHandler>::iterator it = _cmdMap.find(split_msg[0]);
+			if (it != _cmdMap.end())
+				(this->*(it->second))(client, message, split_msg);
+			else
+				sendMessage(client.getFd(), "421 " + client.getNickname() + " " + split_msg[0] + " :Unknown command");
+			// if (split_msg[0].compare("PASS") == 0)
+			// 	if (!authPass(client, split_msg[1], _password))
+			// 		Server::removeClient(client.getFd());
+			// if (split_msg[0].compare("NICK") == 0 && isNewNick(_clients, split_msg[1]))
+			// 	setClientNick(split_msg[1], client);
+			// if (split_msg[0].compare("USER") == 0)
+			// 	setClientUsername(message, split_msg, client);
 		}
 		std::cout << client.getNickname() << std::endl;
 		std::cout << client.getUsername() << std::endl;
@@ -200,17 +205,22 @@ void    Server::broadcastToChannel(const std::string &channelName, const std::st
 
 void	Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	if (!authPass(client, rawMsg, _password))
+	(void)rawMsg;
+	if (!authPass(client, tokens[1], _password))
 		Server::removeClient(client.getFd());
 }
 
 void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	if (rawMsg.compare("NICK") == 0 && isNewNick(_clients, tokens[1]))
+		setClientNick(tokens[1], client);
 
 }
 
 void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	if (tokens[0].compare("USER") == 0)
+		setClientUsername(rawMsg, tokens, client);
 
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -19,6 +19,7 @@ Server::Server(int port, const std::string &password) {
     _password = password;
     _serverSocketFd = -1;
     _running = false;
+	initCommandMap();
 }
 
 Server::~Server() {
@@ -195,6 +196,29 @@ void    Server::broadcastToChannel(const std::string &channelName, const std::st
             continue;
         sendMessage(*index, message);
     }
+}
+
+void	Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	if (!authPass(client, rawMsg, _password))
+		Server::removeClient(client.getFd());
+}
+
+void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+
+}
+
+void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+
+}
+
+void	Server::initCommandMap()
+{
+	_cmdMap["PASS"] = &Server::handlePass;
+	_cmdMap["NICK"] = &Server::handleNick;
+	_cmdMap["USER"] = &Server::handleUser;
 }
 
 void    Server::handleClientData(int clientFd)


### PR DESCRIPTION
## Summary
Replace if/else command routing with a map-based command dispatcher.

## Changes
- Add CommandHandler typedef and _cmdMap in Server.hpp
- Add initCommandMap() to register PASS/NICK/USER handlers
- Replace if-chain in processClientBuffer with map lookup
- Return 421 ERR_UNKNOWNCOMMAND for unknown commands
- Add token size guards to prevent segfault on bare commands
- Remove duplicate declarations in Utils.hpp

## Checklist
- [x] Commands routed correctly
- [x] Unknown commands return 421
- [x] Compiles with -Wall -Wextra -Werror
- [x] No segfault on bare commands