### PR TITLE
feat(messages): implement IRC server response numerics and welcome burst

### DIFF
--- a/includes/client/Client.hpp
+++ b/includes/client/Client.hpp
@@ -11,10 +11,11 @@ private:
     std::string _username;
 	std::string _realname;
     std::string _inputBuffer;
+	std::string	_host;
     bool    _isAuthenticated;
 	bool	_isRegistered;
 public:
-    Client(int fd);
+    Client(int fd, std::string& host);
     ~Client();
     
     // Getters
@@ -22,6 +23,7 @@ public:
     const std::string& getNickname() const;
     const std::string& getUsername() const;
     const std::string& getRealname() const;
+    const std::string& getHost() const;
     std::string& getInputBuffer();
     bool    getIsAuthenticated() const;
 	bool	getIsRegistered() const;

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -13,6 +13,7 @@ class Server
 {
 private:
     // Server atributes
+	const std::string	_serverName;
     int _port;
     std::string _password;
     int _serverSocketFd;
@@ -42,7 +43,6 @@ private:
 	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	std::string	code_string(unsigned int code);
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -14,6 +14,7 @@ class Server
 private:
     // Server atributes
 	const std::string	_serverName;
+	const std::string	_version;
     int _port;
     std::string _password;
     int _serverSocketFd;

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -15,6 +15,7 @@ private:
     // Server atributes
 	const std::string	_serverName;
 	const std::string	_version;
+	const std::string	_creationDate;
     int _port;
     std::string _password;
     int _serverSocketFd;

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -40,6 +40,7 @@ private:
     void    processClientBuffer(Client &client);
     void    removeClient(int clientFd);
     void    sendMessage(int clientFd, const std::string &message);
+	void	sendWelcomeMessage(Client &client);
     void    broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd);
 	void	initCommandMap();
 	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -42,6 +42,7 @@ private:
 	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	std::string	code_string(unsigned int code);
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -3,6 +3,7 @@
 
 # include <iostream>
 # include <vector>
+#include <map>
 # include <string>
 # include "../client/Client.hpp"
 
@@ -25,7 +26,7 @@ const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 
 std::string	authPass(Client &client, std::string password, std::string server_password);
-void	setClientNick(std::string nickname, Client &client);
+std::string	setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
 bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -6,6 +6,23 @@
 # include <string>
 # include "../client/Client.hpp"
 
+const std::string	RPL_WELCOME = "001";
+const std::string	RPL_YOURHOST = "002";
+const std::string	RPL_CREATED = "003";
+const std::string	RPL_MYINFO = "004";
+
+const std::string	ERR_UNKNOWNCOMMAND = "421";
+const std::string	ERR_NONICKNAMEGIVEN = "431";
+const std::string	ERR_ERRONEUSNICKNAME = "432";
+const std::string	ERR_NICKNAMEINUSE = "433";
+const std::string	ERR_NOTREGISTERED = "451";
+const std::string	ERR_NEEDMOREPARAMS = "461";
+const std::string	ERR_ALREADYREGISTRED = "462";
+const std::string	ERR_PASSWDMISMATCH = "464";
+
+const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
+
+
 bool	authPass(Client &client, std::string password, std::string server_password);
 void	setClientNick(std::string nickname, Client &client);
 bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -22,11 +22,16 @@ const std::string	ERR_NEEDMOREPARAMS = "461";
 const std::string	ERR_ALREADYREGISTRED = "462";
 const std::string	ERR_PASSWDMISMATCH = "464";
 
+const std::string	ERR_INVALIDUSERNAME = "900";
+const std::string	ERR_INVALIDMODE = "901";
+const std::string	ERR_INVALIDUNUSED = "902";
+const std::string	ERR_INVALIDREALNAME = "903";
+
 const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 
 std::string	authPass(Client &client, std::string password, std::string server_password);
 std::string	setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
-bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
+std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -6,6 +6,7 @@
 # include <string>
 # include "../client/Client.hpp"
 
+const std::string	RPL_SUCCESS = "000";
 const std::string	RPL_WELCOME = "001";
 const std::string	RPL_YOURHOST = "002";
 const std::string	RPL_CREATED = "003";
@@ -23,7 +24,7 @@ const std::string	ERR_PASSWDMISMATCH = "464";
 const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 
-bool	authPass(Client &client, std::string password, std::string server_password);
+std::string	authPass(Client &client, std::string password, std::string server_password);
 void	setClientNick(std::string nickname, Client &client);
 bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 

--- a/src/client/Client.cpp
+++ b/src/client/Client.cpp
@@ -1,7 +1,7 @@
 #include "../../includes/client/Client.hpp"
 #include <unistd.h>
 
-Client::Client(int fd): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _isAuthenticated(false), _isRegistered(false) {}
+Client::Client(int fd, std::string& host): _fd(fd), _nickname(""), _username(""), _inputBuffer(""), _host(host), _isAuthenticated(false), _isRegistered(false) {}
 
 Client::~Client() {}
 
@@ -19,6 +19,10 @@ const std::string& Client::getUsername() const {
 
 const std::string& Client::getRealname() const {
 	return (_realname);
+}
+
+const std::string& Client::getHost() const {
+	return (_host);
 }
 
 std::string& Client::getInputBuffer() {

--- a/src/commands/NICK.cpp
+++ b/src/commands/NICK.cpp
@@ -10,31 +10,43 @@ bool	isSpecial(char c)
 	return (false);
 }
 
-void	setClientNick(std::string nickname, Client &client)
+bool	isNewNick(std::map<int, Client> &clients, std::string nickname)
 {
-	if (client.getIsAuthenticated())
+	for (std::map<int, Client>::iterator it = clients.begin(); it != clients.end(); ++it)
 	{
-		if (nickname.length() < 1 || nickname.length() > 9)
-		{
-			std::cout << "Ivalid nick: nickname must be between 1 and 9" << std::endl;
-			return ;
-		}
-		if (!std::isalpha(nickname[0]) && !isSpecial(nickname[0]))
-		{
-			std::cout << "Ivalid nick: first character must be alpha or special" << std::endl;
-			return ;
-		}
-		for (std::string::iterator it = nickname.begin(); it != nickname.end(); ++it)
-		{
-			if (!std::isalpha(*it) && !std::isdigit(*it) && !isSpecial(*it))
-			{
-				std::cout << "Ivalid nick: invalid character: " << *it << std::endl;
-				return ;
-			}
-		}
-		client.setNickname(nickname);
-		std::cout << "nick set: " << client.getNickname() << std::endl;
+		Client client = it->second;
+		if (client.getNickname().compare(nickname) == 0)
+			return (false);
 	}
-	else
-		std::cout << "Client not authenticated" << std::endl;
+	return (true);
+}
+
+std::string	setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients)
+{
+	if (nickname.length() < 1 || nickname.length() > 9)
+	{
+		std::cout << "Ivalid nick: nickname must be between 1 and 9. Client FD: " << client.getFd() << std::endl;
+		return (ERR_ERRONEUSNICKNAME);
+	}
+	if (!std::isalpha(nickname[0]) && !isSpecial(nickname[0]))
+	{
+		std::cout << "Ivalid nick: first character must be alpha or special. Client FD: " << client.getFd() << std::endl;
+		return (ERR_ERRONEUSNICKNAME);
+	}
+	if (!isNewNick(clients, nickname))
+	{
+		std::cout << "Nick " << nickname << " has already been registered. Client FD: " << client.getFd() << std::endl;
+		return (ERR_NICKNAMEINUSE);
+	}
+	for (std::string::iterator it = nickname.begin(); it != nickname.end(); ++it)
+	{
+		if (!std::isalpha(*it) && !std::isdigit(*it) && !isSpecial(*it))
+		{
+			std::cout << "Ivalid nick: invalid character: " << *it << ". Client FD: " << client.getFd() << std::endl;
+			return (ERR_ERRONEUSNICKNAME);
+		}
+	}
+	client.setNickname(nickname);
+	std::cout << "nick set: " << client.getNickname() << std::endl;
+	return (RPL_SUCCESS);
 }

--- a/src/commands/PASS.cpp
+++ b/src/commands/PASS.cpp
@@ -3,17 +3,12 @@
 
 bool	authPass(Client &client, std::string password, std::string server_password)
 {
-	if (client.getIsAuthenticated())
+	if (server_password.compare(password) == 0)
 	{
-		std::cout << "Client already authenticated" << std::endl;
-		return (true);
-	}
-	else if (server_password.compare(password) == 0)
-	{
-		std::cout << "Password accepted" << std::endl;
+		std::cout << "Password accepted from FD: " << client.getFd() << std::endl;
 		client.setIsAuthenticated(true);
 		return (true);
 	}
-		std::cout << "Wrong password" << std::endl;
+		std::cout << "Wrong password from FD: " << client.getFd() << std::endl;
 	return (false);
 }

--- a/src/commands/PASS.cpp
+++ b/src/commands/PASS.cpp
@@ -1,14 +1,20 @@
 #include "../../includes/client/Client.hpp"
+#include "../../includes/utils/Utils.hpp"
 #include <iostream>
 
-bool	authPass(Client &client, std::string password, std::string server_password)
+std::string	authPass(Client &client, std::string password, std::string server_password)
 {
-	if (server_password.compare(password) == 0)
+	if (client.getIsAuthenticated())
 	{
+		std::cout << "Client FD: " << client.getFd() << " already authenticated" << std::endl;
+		return ERR_ALREADYREGISTRED;
+	}
+	if (server_password.compare(password) != 0)
+	{
+		std::cout << "Wrong password from FD: " << client.getFd() << std::endl;
+		return (ERR_PASSWDMISMATCH);
+	}
 		std::cout << "Password accepted from FD: " << client.getFd() << std::endl;
 		client.setIsAuthenticated(true);
-		return (true);
-	}
-		std::cout << "Wrong password from FD: " << client.getFd() << std::endl;
-	return (false);
+		return (RPL_SUCCESS);
 }

--- a/src/commands/USER.cpp
+++ b/src/commands/USER.cpp
@@ -3,30 +3,22 @@
 #include <iostream>
 #include <string>
 
-bool	parseUsername(std::string username)
+bool	parseUsername(std::string username, Client &client)
 {
 	size_t	found;
 
 	if (username.empty() || username.size() > 32)
 	{
-		std::cout << "Username empty or too large" << std::endl;
+		std::cout << "Username empty or too large. Client FD: " << client.getFd() << std::endl;
 		return (false);
 	}
 	found = username.find_first_of(" @!:\r\n\0"); 
 	if (found != std::string::npos)
 	{
-		std::cout << "Character " << username[found] << " is forbidden" << std::endl;
+		std::cout << "Character " << username[found] << " is forbidden. Client FD:" << client.getFd() << std::endl;
 		return false;
 	}
-	std::cout << "username accepted -> " << username << std::endl;
-	return (true);
-}
-
-bool	parseRealName(std::vector<std::string> subvec)
-{
-	for (std::vector<std::string>::iterator it = subvec.begin(); it != subvec.end(); ++it) {
-		std::cout << *it << std::endl;
-	}
+	std::cout << "username accepted -> " << username << ". Client FD: " << client.getFd() << std::endl;
 	return (true);
 }
 
@@ -42,58 +34,44 @@ bool	fetchRealName(std::string message, Client &client)
 	found = realName.find_first_of("\r\n\0");
 	if (found != std::string::npos)
 	{
-		std::cout << "Invalid real name" << std::endl;	
+		std::cout << "Invalid real name. Client FD: " << client.getFd() << std::endl;	
 		return (false);
 	}
 	client.setRealname(realName);
 	return (true);
 }
 
-bool	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
+std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
 {
 	std::string realname;
 
-	if (!client.getIsAuthenticated())
+	for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
 	{
-		std::cout << "Client not authenticated" << std::endl;
-		return (false);
-	}
-	else
-	{
-		if (split_msg.size() < 5)
-		{
-			std::cout << "Not enough parameters" << std::endl;
-			return false;
+		int index = it - split_msg.begin();
+		switch (index) {
+			case 1:
+				if (!parseUsername(*it, client))
+					return (ERR_INVALIDUSERNAME);
+				else
+					client.setUsername(*it);
+				break ;
+			case 2:
+				if (it->compare("0") != 0)
+				{
+					std::cout << "Invalid mode " << *it << std::endl;
+					return (ERR_INVALIDMODE);
+				}
+				break ;
+			case 3:
+				if (it->compare("*") != 0)
+				{
+					std::cout << "This unused " << *it << " is invalid" << std::endl;	
+					return (ERR_INVALIDUNUSED);
+				}
+				break ;
 		}
-		for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
-		{
-			int index = it - split_msg.begin();
-
-			switch (index) {
-				case 1:
-					if (!parseUsername(*it))
-						return (false);
-					else
-						client.setUsername(*it);
-					break ;
-				case 2:
-					if (it->compare("0") != 0)
-					{
-						std::cout << "Invalid mode " << *it << std::endl;
-						return (false);
-					}
-					break ;
-				case 3:
-					if (it->compare("*") != 0)
-					{
-						std::cout << "This unused " << *it << " is invalid" << std::endl;	
-						return (false);
-					}
-					break ;
-			}
-		}
-		if (!fetchRealName(message, client))
-			return (false);
 	}
-	return (true);
+	if (!fetchRealName(message, client))
+		return (ERR_INVALIDREALNAME);
+	return (RPL_SUCCESS);
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -199,9 +199,21 @@ void	Server::handlePass(Client &client, const std::string &rawMsg, const std::ve
 {
 	(void)rawMsg;
 	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
 		return ;
+	}
+	if (client.getIsAuthenticated())
+	{
+		std::cout << "Client already authenticated" << std::endl;
+		sendMessage(client.getFd(), ERR_ALREADYREGISTRED + " PASS " + ":You may not register");
+		return ;
+	}
 	if (!authPass(client, tokens[1], _password))
+	{
+		sendMessage(client.getFd(), ERR_PASSWDMISMATCH + " PASS " + ":Password incorrect");
 		Server::removeClient(client.getFd());
+	}
 }
 
 void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -136,6 +136,11 @@ void    Server::processClientBuffer(Client &client)
         std::cout << "Received command: " << message << std::endl;
 		if (!split_msg.empty())
 		{
+			if (split_msg.size() < 2)
+			{
+				sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " " + split_msg[0] + " " + MSG_NEEDMOREPARAMS);
+				continue;
+			}
 			std::map<std::string, CommandHandler>::iterator it = _cmdMap.find(split_msg[0]);
 			if (it != _cmdMap.end())
 				(this->*(it->second))(client, message, split_msg);
@@ -148,7 +153,6 @@ void    Server::processClientBuffer(Client &client)
 			sendWelcomeMessage(client);
 			client.setIsRegistered(true);
 		}
-		// TODO message if command has no parameters
     }
 }
 
@@ -209,11 +213,6 @@ void	Server::handlePass(Client &client, const std::string &rawMsg, const std::ve
 	std::string	res;
 	
 	(void)rawMsg;
-	if (tokens.size() < 2)
-	{
-		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
-		return ;
-	}
 	res = authPass(client, tokens[1], _password);
 	if (res.compare(ERR_ALREADYREGISTRED) == 0)
 		sendMessage(client.getFd(), ERR_ALREADYREGISTRED + " PASS " + ":You may not reregister");
@@ -229,11 +228,6 @@ void	Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 	std::string	res;
 
 	(void)rawMsg;
-	if (tokens.size() < 2)
-	{
-		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " NICK " + MSG_NEEDMOREPARAMS);
-		return ;
-	}
 	res = setClientNick(tokens[1], client, _clients);
 	if (res.compare(ERR_ERRONEUSNICKNAME) == 0)
 		sendMessage(client.getFd(), ERR_ERRONEUSNICKNAME + " NICK " + ":Erroneous Nickname");
@@ -245,11 +239,6 @@ void	Server::handleUser(Client &client, const std::string &rawMsg, const std::ve
 {
 	std::string	res;
 
-	if (tokens.size() < 2)
-	{
-		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + MSG_NEEDMOREPARAMS);
-		return ;
-	}
 	res = setClientUsername(rawMsg, tokens, client);
 	if (res.compare(ERR_INVALIDUSERNAME) == 0)
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid username");

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -15,7 +15,7 @@
 #include <cerrno>
 #include <set>
 
-Server::Server(int port, const std::string &password) : _serverName("ircat"){
+Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"){
     _port = port;
     _password = password;
     _serverSocketFd = -1;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -140,7 +140,7 @@ void    Server::processClientBuffer(Client &client)
 			if (it != _cmdMap.end())
 				(this->*(it->second))(client, message, split_msg);
 			else
-				sendMessage(client.getFd(), "421" + client.getNickname() + " " + split_msg[0] + " :Unknown command");
+				sendMessage(client.getFd(), ERR_UNKNOWNCOMMAND + " " + (client.getNickname().empty() ? "*" : client.getNickname()) + " " + split_msg[0] + " :Unknown command");
 		}
 		if (!client.getIsRegistered() && client.getIsAuthenticated() 
 			&& !client.getNickname().empty() && !client.getUsername().empty())

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -221,9 +221,22 @@ void	Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 
 void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	std::string	res;
+
 	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + MSG_NEEDMOREPARAMS);
 		return ;
-	setClientUsername(rawMsg, tokens, client);
+	}
+	res = setClientUsername(rawMsg, tokens, client);
+	if (res.compare(ERR_INVALIDUSERNAME) == 0)
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid username");
+	if (res.compare(ERR_INVALIDMODE) == 0)
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid mode (not 0)");
+	if (res.compare(ERR_INVALIDUNUSED) == 0)
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid unused (not *)");
+	if (res.compare(ERR_INVALIDREALNAME) == 0)
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid realname");
 }
 
 std::string	Server::code_string(unsigned int code)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -86,7 +86,13 @@ void    Server::setupPolling() {
 void    Server::handleNewConnection() {
     while (true)
     {
-        int clientFd = accept(_serverSocketFd, NULL, NULL);
+		
+		struct sockaddr_in	clientAddr;
+		socklen_t			addrLen;
+
+		addrLen = sizeof(clientAddr);
+        int clientFd = accept(_serverSocketFd, (struct sockaddr*)&clientAddr, &addrLen);
+		std::string	clientHost = inet_ntoa(clientAddr.sin_addr);
         if (clientFd < 0)
         {
             if (errno == EWOULDBLOCK || errno == EAGAIN)
@@ -95,7 +101,7 @@ void    Server::handleNewConnection() {
                 throw std::runtime_error("Accept execution failed");
         }
         fcntl(clientFd, F_SETFL, O_NONBLOCK);
-        _clients.insert(std::make_pair(clientFd, Client(clientFd)));
+        _clients.insert(std::make_pair(clientFd, Client(clientFd, clientHost)));
         pollfd clientPollFd;
         clientPollFd.fd = clientFd;
         clientPollFd.events = POLLIN;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -2,6 +2,7 @@
 #include "../../includes/client/Client.hpp"
 #include "../../includes/utils/Utils.hpp"
 #include <sstream>
+#include <string>
 #include <sys/socket.h>
 #include <stdexcept>
 #include <unistd.h>
@@ -147,7 +148,7 @@ void    Server::processClientBuffer(Client &client)
 			if (it != _cmdMap.end())
 				(this->*(it->second))(client, message, split_msg);
 			else
-				sendMessage(client.getFd(), "421 " + client.getNickname() + " " + split_msg[0] + " :Unknown command");
+				sendMessage(client.getFd(), "421" + client.getNickname() + " " + split_msg[0] + " :Unknown command");
 		}
 		if (!client.getIsRegistered() && client.getIsAuthenticated() 
 			&& !client.getNickname().empty() && !client.getUsername().empty())
@@ -197,22 +198,21 @@ void    Server::broadcastToChannel(const std::string &channelName, const std::st
 
 void	Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	std::string	res;
+	
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
 		return ;
 	}
-	if (client.getIsAuthenticated())
+	res = authPass(client, tokens[1], _password);
+	if (res.compare(ERR_ALREADYREGISTRED) == 0)
+		sendMessage(client.getFd(), ERR_ALREADYREGISTRED + " PASS " + ":You may not reregister");
+	if (res.compare(ERR_PASSWDMISMATCH) == 0)
 	{
-		std::cout << "Client already authenticated" << std::endl;
-		sendMessage(client.getFd(), ERR_ALREADYREGISTRED + " PASS " + ":You may not register");
-		return ;
-	}
-	if (!authPass(client, tokens[1], _password))
-	{
-		sendMessage(client.getFd(), ERR_PASSWDMISMATCH + " PASS " + ":Password incorrect");
-		Server::removeClient(client.getFd());
+	 	sendMessage(client.getFd(), ERR_PASSWDMISMATCH + " PASS " + ":Password incorrect");
+		removeClient(client.getFd());
 	}
 }
 
@@ -220,7 +220,10 @@ void	Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 {
 	(void)rawMsg;
 	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
 		return ;
+	}
 	if (isNewNick(_clients, tokens[1]))
 		setClientNick(tokens[1], client);
 }
@@ -230,6 +233,13 @@ void	Server::handleUser(Client &client, const std::string &rawMsg, const std::ve
 	if (tokens.size() < 2)
 		return ;
 	setClientUsername(rawMsg, tokens, client);
+}
+
+std::string	Server::code_string(unsigned int code)
+{
+	std::stringstream	ss;
+	ss << code;
+	return (ss.str());
 }
 
 void	Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -15,7 +15,7 @@
 #include <cerrno>
 #include <set>
 
-Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"){
+Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__){
     _port = port;
     _password = password;
     _serverSocketFd = -1;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -117,20 +117,6 @@ std::vector<std::string> split(const std::string message)
 	return (res);
 }
 
-bool	isNewNick(std::map<int, Client> &clients, std::string nickname)
-{
-	for (std::map<int, Client>::iterator it = clients.begin(); it != clients.end(); ++it)
-	{
-		Client client = it->second;
-		if (client.getNickname().compare(nickname) == 0)
-		{
-			std::cout << "Nick " << nickname << " has already been registered. Choose another." << std::endl;
-			return (false);
-		}
-	}
-	return (true);
-}
-
 void    Server::processClientBuffer(Client &client)
 {
 	std::string &buf = client.getInputBuffer();
@@ -218,14 +204,19 @@ void	Server::handlePass(Client &client, const std::string &rawMsg, const std::ve
 
 void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	std::string	res;
+
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
-		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " NICK " + MSG_NEEDMOREPARAMS);
 		return ;
 	}
-	if (isNewNick(_clients, tokens[1]))
-		setClientNick(tokens[1], client);
+	res = setClientNick(tokens[1], client, _clients);
+	if (res.compare(ERR_ERRONEUSNICKNAME) == 0)
+		sendMessage(client.getFd(), ERR_ERRONEUSNICKNAME + " NICK " + ":Erroneous Nickname");
+	if (res.compare(ERR_NICKNAMEINUSE) == 0)
+		sendMessage(client.getFd(), ERR_NICKNAMEINUSE + " NICK " + ":Nickname is already in use");
 }
 
 void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -144,7 +144,10 @@ void    Server::processClientBuffer(Client &client)
 		}
 		if (!client.getIsRegistered() && client.getIsAuthenticated() 
 			&& !client.getNickname().empty() && !client.getUsername().empty())
+		{
+			sendWelcomeMessage(client);
 			client.setIsRegistered(true);
+		}
 		// TODO message if command has no parameters
     }
 }
@@ -171,6 +174,19 @@ void    Server::sendMessage(int clientFd, const std::string &message)
     bytes_send = send(clientFd, formatted.c_str(), formatted.size(), 0);
     if (bytes_send < 0)
         std::cerr << "Send failed to client fd: " << clientFd << std::endl;
+}
+
+void	Server::sendWelcomeMessage(Client &client)
+{
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_WELCOME
+		+ " " + client.getNickname() + " :Welcome to our IRC network "
+		+ client.getNickname() + "!" + client.getUsername() + "@" + client.getHost());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_YOURHOST
+		+ " " + client.getNickname() + " :Your host is " + _serverName + ", running version " + _version);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CREATED
+		+ " " + client.getNickname() + " :This server was created at " + _creationDate);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_MYINFO
+		+ " " + _serverName + " " + _version + " o o");
 }
 
 void    Server::broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -15,7 +15,7 @@
 #include <cerrno>
 #include <set>
 
-Server::Server(int port, const std::string &password) {
+Server::Server(int port, const std::string &password) : _serverName("ircat"){
     _port = port;
     _password = password;
     _serverSocketFd = -1;
@@ -237,13 +237,6 @@ void	Server::handleUser(Client &client, const std::string &rawMsg, const std::ve
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid unused (not *)");
 	if (res.compare(ERR_INVALIDREALNAME) == 0)
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid realname");
-}
-
-std::string	Server::code_string(unsigned int code)
-{
-	std::stringstream	ss;
-	ss << code;
-	return (ss.str());
 }
 
 void	Server::initCommandMap()


### PR DESCRIPTION
## Description

Implement IRC protocol message responses for PASS, NICK, USER commands, add client registration welcome burst (001–004), and handle unknown commands.

## Changes

### Server (`Server.hpp`, `Server.cpp`)
- Added `_serverName`, `_version`, `_creationDate` private members (initialized in constructor with `__DATE__` + `__TIME__`)
- Added `_host` to Client for `<nick>!<user>@<host>` in welcome message
- `handleNewConnection()` now captures client IP via `accept()` + `inet_ntoa()`
- Added `sendWelcomeMessage()` — sends RPL_WELCOME (001), RPL_YOURHOST (002), RPL_CREATED (003), RPL_MYINFO (004)
- RPL_MYINFO (004) sends hardcoded user mode `o` and channel mode `o`
- Added `handlePass()`, `handleNick()`, `handleUser()` — send IRC numeric replies instead of `std::cout`
- Added unknown command handling → 421 with `*` fallback when nickname is unset
- Added missing parameter guard → 461
- NICK and USER can run before PASS (common IRC server behavior)

### Utils (`Utils.hpp`)
- Added `const std::string` numeric constants: RPL_WELCOME (001), RPL_YOURHOST (002), RPL_CREATED (003), RPL_MYINFO (004), ERR_UNKNOWNCOMMAND (421), ERR_NONICKNAMEGIVEN (431), ERR_ERRONEUSNICKNAME (432), ERR_NICKNAMEINUSE (433), ERR_NOTREGISTERED (451), ERR_NEEDMOREPARAMS (461), ERR_ALREADYREGISTRED (462), ERR_PASSWDMISMATCH (464)
- Added `MSG_NEEDMOREPARAMS` message constant
- Updated function signatures: `authPass()`, `setClientNick()`, `setClientUsername()` now return `std::string`

### Commands
- **PASS.cpp**: Returns error codes (`ERR_ALREADYREGISTRED`, `ERR_PASSWDMISMATCH`) instead of void; success sends nothing back
- **NICK.cpp**: Returns error codes (`ERR_ERRONEUSNICKNAME`, `ERR_NICKNAMEINUSE`) or `RPL_SUCCESS`
- **USER.cpp**: Returns error codes (`ERR_INVALIDUSERNAME`, `ERR_INVALIDMODE`, `ERR_INVALIDUNUSED`, `ERR_INVALIDREALNAME`) or `RPL_SUCCESS`

### Client (`Client.hpp`, `Client.cpp`)
- Added `_host` member and `getHost()` getter
- Constructor now accepts `host` parameter

## Notes
- NICK and USER commands can be executed before PASS, following common IRC server convention
- Custom const variables added for USER command message handling
- Welcome message RPL_MYINFO (004) sends hardcoded user mode `o` and channel mode `o` — will be dynamic as more modes are implemented
- Step 7 (pre-registration guard for non-registration commands → 451) will be implemented in a future iteration as the project evolves