### PR TITLE
Implement JOIN command (closes #36)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CPP = c++
 FLAGS = -Wall -Werror -Wextra -std=c++98
 	   
 SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp src/server/Channel.cpp \
-src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp
+src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -1,48 +1,51 @@
 #ifndef CHANNEL_HPP
 #define CHANNEL_HPP
 
-#include <string>
 #include <set>
+#include <string>
 
 class Channel
 {
-private:
-    std::string		_name;
-    std::set<int>	_clients;
-    std::set<int>	_operators;
-	std::string		_topic;
-	std::string		_modes;
-	std::string		_key;
-	std::set<int>	_inviteList;
-	int				_userLimit;
-public:
-    Channel(const std::string &name);
+  private:
+	std::string _name;
+	std::set<int> _clients;
+	std::set<int> _operators;
+	std::string _topic;
+	std::string _modes;
+	std::string _key;
+	std::set<int> _inviteList;
+	int _userLimit;
+
+  public:
+	Channel();
+	Channel(const std::string &name);
+	Channel &operator=(const Channel &other);
 
 	const std::string &getName() const;
 	const std::set<int> &getClients() const;
-	const std::string	&getTopic() const;
-	const std::string	&getModes() const;
-	const std::string	&getKey() const;
-	const int			&getUserLimit() const;
-	
-	void	setTopic(std::string &topic);
-	void	setModes(std::string &modes);
-	void	setKey(std::string &key);
-	void	setUserLimit(int limit);
+	const std::string &getTopic() const;
+	const std::string &getModes() const;
+	const std::string &getKey() const;
+	const int &getUserLimit() const;
 
-	void	addClient(int clientFd);
-    void	addOperator(int clientFd);
-	void	addInvite(int clientFd);
-	void	addMode(char mode);
+	void setTopic(std::string &topic);
+	void setModes(std::string &modes);
+	void setKey(std::string &key);
+	void setUserLimit(int limit);
 
-	bool	isMember(int clientFd) const;
-    bool	isOperator(int clientFd) const;
-	bool	isInvited(int clientFd) const;
-	bool	hasMode(char mode) const;
+	void addClient(int clientFd);
+	void addOperator(int clientFd);
+	void addInvite(int clientFd);
+	void addMode(char mode);
 
-	void	removeMode(char mode);
-	void	removeInvite(int clientFd);
-    void	removeClient(int clientFd);
+	bool isMember(int clientFd) const;
+	bool isOperator(int clientFd) const;
+	bool isInvited(int clientFd) const;
+	bool hasMode(char mode) const;
+
+	void removeMode(char mode);
+	void removeInvite(int clientFd);
+	void removeClient(int clientFd);
 };
 
 #endif

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -14,7 +14,7 @@ class Channel
 	std::string _modes;
 	std::string _key;
 	std::set<int> _inviteList;
-	int _userLimit;
+	unsigned int _userLimit;
 
   public:
 	Channel();
@@ -27,12 +27,12 @@ class Channel
 	const std::string &getTopic() const;
 	const std::string &getModes() const;
 	const std::string &getKey() const;
-	const int &getUserLimit() const;
+	const unsigned int &getUserLimit() const;
 
 	void setTopic(std::string &topic);
 	void setModes(std::string &modes);
-	void setKey(std::string &key);
-	void setUserLimit(int limit);
+	void setKey(std::string key);
+	void setUserLimit(unsigned int limit);
 
 	void addClient(int clientFd);
 	void addOperator(int clientFd);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -29,7 +29,7 @@ class Channel
 	const std::string &getKey() const;
 	const unsigned int &getUserLimit() const;
 
-	void setTopic(std::string &topic);
+	void setTopic(std::string topic);
 	void setModes(std::string &modes);
 	void setKey(std::string key);
 	void setUserLimit(unsigned int limit);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -23,6 +23,7 @@ class Channel
 
 	const std::string &getName() const;
 	const std::set<int> &getClients() const;
+	const std::set<int> &getOperators() const;
 	const std::string &getTopic() const;
 	const std::string &getModes() const;
 	const std::string &getKey() const;

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -18,6 +18,7 @@ private:
 public:
     Channel(const std::string &name);
 
+	const std::string &getName() const;
 	const std::set<int> &getClients() const;
 	const std::string	&getTopic() const;
 	const std::string	&getModes() const;

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -46,7 +46,9 @@ private:
 	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void	handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void	handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	bool	checkForParams(Client &client, std::string commmand, unsigned int size);
+	std::string	showClientsInChannel(Channel &channel);
 public:
     // Constructors
     Server(int port, const std::string& password);

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -1,63 +1,65 @@
 #ifndef SERVER_HPP
 #define SERVER_HPP
 
-#include <string>
-#include <vector>
 #include <map>
 #include <poll.h>
+#include <string>
+#include <vector>
 
-#include "Channel.hpp"
 #include "../client/Client.hpp"
+#include "Channel.hpp"
 
 class Server
 {
-private:
-    // Server atributes
-	const std::string	_serverName;
-	const std::string	_version;
-	const std::string	_creationDate;
-    int _port;
-    std::string _password;
-    int _serverSocketFd;
-    bool    _running;
-    std::map<int, Client>  _clients; 
-    std::vector<pollfd> _pollFds;
-    std::map<std::string, Channel> _channels;
-	typedef void (Server::*CommandHandler)(Client&, const std::string&, const std::vector<std::string>&);
+  private:
+	// Server atributes
+	const std::string _serverName;
+	const std::string _version;
+	const std::string _creationDate;
+	int _port;
+	std::string _password;
+	int _serverSocketFd;
+	bool _running;
+	std::map<int, Client> _clients;
+	std::vector<pollfd> _pollFds;
+	std::map<std::string, Channel> _channels;
+	typedef void (Server::*CommandHandler)(Client &, const std::string &, const std::vector<std::string> &);
 	std::map<std::string, CommandHandler> _cmdMap;
 
-    // Server private methods
-    void    setupSocketOpts();
-    void    setupServerAddress();
-    void    setupListen();
-    void    setupSocket();
-    void    setupNonBlocking();
-    void    setupServerPoll();
-    void    setupPolling();
-    void    runPollLoop();
-    void    handleNewConnection();
-    void    handleClientData(int clientFd);
-    void    processClientBuffer(Client &client);
-    void    removeClient(int clientFd);
-    void    sendMessage(int clientFd, const std::string &message);
-	void	sendWelcomeMessage(Client &client);
-    void    broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd);
-	void	initCommandMap();
-	void	handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	void	handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	void	handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	void	handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	void	handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	void	handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
-	bool	checkForParams(Client &client, std::string commmand, unsigned int size);
-	std::string	showClientsInChannel(Channel &channel);
-public:
-    // Constructors
-    Server(int port, const std::string& password);
-    ~Server();
-    
-    // Server public method
-    void    start();
+	// Server private methods
+	void setupSocketOpts();
+	void setupServerAddress();
+	void setupListen();
+	void setupSocket();
+	void setupNonBlocking();
+	void setupServerPoll();
+	void setupPolling();
+	void runPollLoop();
+	void handleNewConnection();
+	void handleClientData(int clientFd);
+	void processClientBuffer(Client &client);
+	void removeClient(int clientFd);
+	void sendMessage(int clientFd, const std::string &message);
+	void sendWelcomeMessage(Client &client);
+	void broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd);
+	void initCommandMap();
+	void handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	bool checkForParams(Client &client, std::string commmand, unsigned int size);
+	void sendJoinMessage(Client &client, Channel &channel);
+	std::string showClientsInChannel(Channel &channel);
+
+  public:
+	// Constructors
+	Server(int port, const std::string &password);
+	~Server();
+
+	// Server public method
+	void start();
 };
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -2,62 +2,64 @@
 #define UTILS_HPP
 
 #include "../client/Client.hpp"
+#include "../server/Channel.hpp"
 #include <iostream>
 #include <map>
 #include <string>
 #include <vector>
 
 /* Welcome reply */
-const std::string	RPL_SUCCESS = "000";
-const std::string	RPL_WELCOME = "001";
-const std::string	RPL_YOURHOST = "002";
-const std::string	RPL_CREATED = "003";
-const std::string	RPL_MYINFO = "004";
+const std::string RPL_SUCCESS = "000";
+const std::string RPL_WELCOME = "001";
+const std::string RPL_YOURHOST = "002";
+const std::string RPL_CREATED = "003";
+const std::string RPL_MYINFO = "004";
 
 /* Register error replies */
-const std::string	ERR_UNKNOWNCOMMAND = "421";
-const std::string	ERR_NONICKNAMEGIVEN = "431";
-const std::string	ERR_ERRONEUSNICKNAME = "432";
-const std::string	ERR_NICKNAMEINUSE = "433";
-const std::string	ERR_NOTREGISTERED = "451";
-const std::string	ERR_NEEDMOREPARAMS = "461";
-const std::string	ERR_ALREADYREGISTRED = "462";
-const std::string	ERR_PASSWDMISMATCH = "464";
+const std::string ERR_UNKNOWNCOMMAND = "421";
+const std::string ERR_NONICKNAMEGIVEN = "431";
+const std::string ERR_ERRONEUSNICKNAME = "432";
+const std::string ERR_NICKNAMEINUSE = "433";
+const std::string ERR_NOTREGISTERED = "451";
+const std::string ERR_NEEDMOREPARAMS = "461";
+const std::string ERR_ALREADYREGISTRED = "462";
+const std::string ERR_PASSWDMISMATCH = "464";
 
 /* Extra register error replies */
-const std::string	ERR_INVALIDUSERNAME = "900";
-const std::string	ERR_INVALIDMODE = "901";
-const std::string	ERR_INVALIDUNUSED = "902";
-const std::string	ERR_INVALIDREALNAME = "903";
+const std::string ERR_INVALIDUSERNAME = "900";
+const std::string ERR_INVALIDMODE = "901";
+const std::string ERR_INVALIDUNUSED = "902";
+const std::string ERR_INVALIDREALNAME = "903";
 
 /* Channel success replies */
-const std::string	RPL_NOTOPIC = "331";
-const std::string	RPL_TOPIC = "332";
-const std::string	RPL_INVITING = "341";
-const std::string	RPL_NAMREPLY = "353";
-const std::string	RPL_ENDOFNAMES = "366";
-const std::string	RPL_CHANNELMODEIS = "324";
+const std::string RPL_NOTOPIC = "331";
+const std::string RPL_TOPIC = "332";
+const std::string RPL_INVITING = "341";
+const std::string RPL_NAMREPLY = "353";
+const std::string RPL_ENDOFNAMES = "366";
+const std::string RPL_CHANNELMODEIS = "324";
 
 /* Channel error replies */
-const std::string	RR_NOSUCHNICK = "401";
-const std::string	ERR_NOSUCHCHANNEL = "403";
-const std::string	ERR_CANNOTSENDTOCHAN = "404";
-const std::string	ERR_TOOMANYCHANNELS = "405";
-const std::string	ERR_USERNOTINCHANNEL = "441";
-const std::string	ERR_NOTONCHANNEL = "442";
-const std::string	ERR_KEYSET = "467";
-const std::string	ERR_CHANNELISFULL = "471";
-const std::string	ERR_UNKNOWNMODE = "472";
-const std::string	ERR_INVITEONLYCHAN = "473";
-const std::string	ERR_BANNEDFROMCHAN = "474";
-const std::string	ERR_BADCHANNELKEY = "475";
-const std::string	ERR_CHANOPRIVSNEEDED = "482";
+const std::string RR_NOSUCHNICK = "401";
+const std::string ERR_NOSUCHCHANNEL = "403";
+const std::string ERR_CANNOTSENDTOCHAN = "404";
+const std::string ERR_TOOMANYCHANNELS = "405";
+const std::string ERR_USERNOTINCHANNEL = "441";
+const std::string ERR_NOTONCHANNEL = "442";
+const std::string ERR_KEYSET = "467";
+const std::string ERR_CHANNELISFULL = "471";
+const std::string ERR_UNKNOWNMODE = "472";
+const std::string ERR_INVITEONLYCHAN = "473";
+const std::string ERR_BANNEDFROMCHAN = "474";
+const std::string ERR_BADCHANNELKEY = "475";
+const std::string ERR_CHANOPRIVSNEEDED = "482";
 
-const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
+const std::string MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 std::string authPass(Client &client, std::string password, std::string server_password);
 std::string setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
+std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -31,6 +31,7 @@ const std::string	ERR_INVALIDUNUSED = "902";
 const std::string	ERR_INVALIDREALNAME = "903";
 
 /* Channel success replies */
+const std::string	RPL_NOTOPIC = "331";
 const std::string	RPL_TOPIC = "332";
 const std::string	RPL_INVITING = "341";
 const std::string	RPL_NAMREPLY = "353";
@@ -57,5 +58,6 @@ const std::string	MSG_NEEDMOREPARAMS = ":Not enough parameters";
 std::string authPass(Client &client, std::string password, std::string server_password);
 std::string setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
+std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 
 #endif

--- a/src/commands/JOIN.cpp
+++ b/src/commands/JOIN.cpp
@@ -1,0 +1,6 @@
+#include "../../includes/utils/Utils.hpp"
+
+std::string	joinChannel(Client &client, std::string channelName, bool isNewChannel)
+{
+	
+}

--- a/src/commands/JOIN.cpp
+++ b/src/commands/JOIN.cpp
@@ -1,3 +1,4 @@
+#include "../../includes/server/Channel.hpp"
 #include "../../includes/utils/Utils.hpp"
 
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel)
@@ -10,5 +11,19 @@ std::string joinChannel(Client &client, std::string channelName, bool isNewChann
 		return ERR_NOTREGISTERED;
 	if (channelName.at(0) != '#' || channelName.find_first_of(forbidden) != std::string::npos)
 		return ERR_NOSUCHCHANNEL;
+	return RPL_SUCCESS;
+}
+
+std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass)
+{
+	if (channel.getModes().find_first_of("l") != std::string::npos)
+		if (channel.getClients().size() >= channel.getUserLimit())
+			return ERR_CHANNELISFULL;
+	if (channel.getModes().find_first_of("i") != std::string::npos)
+		if (!channel.isInvited(clientFd))
+			return ERR_INVITEONLYCHAN;
+	if (channel.getModes().find_first_of("k") != std::string::npos)
+		if (!isKeyPass)
+			return ERR_BADCHANNELKEY;
 	return RPL_SUCCESS;
 }

--- a/src/commands/JOIN.cpp
+++ b/src/commands/JOIN.cpp
@@ -1,12 +1,14 @@
 #include "../../includes/utils/Utils.hpp"
 
-std::string	joinChannel(Client &client, std::string channelName, bool isNewChannel)
+std::string joinChannel(Client &client, std::string channelName, bool isNewChannel)
 {
-	std::string	forbidden = " ,:\a";
+	std::string forbidden = " ,:\a";
 
 	(void)client;
 	(void)isNewChannel;
+	if (!client.getIsRegistered())
+		return ERR_NOTREGISTERED;
 	if (channelName.at(0) != '#' || channelName.find_first_of(forbidden) != std::string::npos)
-		return ERR_NOSUCHCHANNEL ;
+		return ERR_NOSUCHCHANNEL;
 	return RPL_SUCCESS;
 }

--- a/src/commands/JOIN.cpp
+++ b/src/commands/JOIN.cpp
@@ -2,5 +2,11 @@
 
 std::string	joinChannel(Client &client, std::string channelName, bool isNewChannel)
 {
-	
+	std::string	forbidden = " ,:\a";
+
+	(void)client;
+	(void)isNewChannel;
+	if (channelName.at(0) != '#' || channelName.find_first_of(forbidden) != std::string::npos)
+		return ERR_NOSUCHCHANNEL ;
+	return RPL_SUCCESS;
 }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -2,9 +2,9 @@
 #include <algorithm>
 #include <iostream>
 
-Channel::Channel() : _name() {}
+Channel::Channel() : _name(), _clients(), _operators() {}
 
-Channel::Channel(const std::string &name) : _name(name) {}
+Channel::Channel(const std::string &name) : _name(name), _clients(), _operators() {}
 
 Channel &Channel::operator=(const Channel &other)
 {
@@ -47,6 +47,8 @@ bool Channel::isOperator(int clientFd) const { return (_operators.count(clientFd
 const std::string &Channel::getName() const { return _name; }
 
 const std::set<int> &Channel::getClients() const { return _clients; }
+
+const std::set<int> &Channel::getOperators() const { return _operators; };
 
 const std::string &Channel::getTopic() const { return _topic; }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -22,11 +22,7 @@ Channel &Channel::operator=(const Channel &other)
 	return *this;
 }
 
-void Channel::addClient(int clientFd)
-{
-	_clients.insert(clientFd);
-	std::cout << "here " << _clients.size() << std::endl;
-}
+void Channel::addClient(int clientFd) { _clients.insert(clientFd); }
 
 void Channel::removeClient(int clientFd)
 {
@@ -58,7 +54,7 @@ const std::string &Channel::getKey() const { return _key; }
 
 const unsigned int &Channel::getUserLimit() const { return _userLimit; }
 
-void Channel::setTopic(std::string &topic) { _topic = topic; }
+void Channel::setTopic(std::string topic) { _topic = topic; }
 
 void Channel::setModes(std::string &modes) { _modes = modes; }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -1,112 +1,81 @@
 #include "../../includes/server/Channel.hpp"
 #include <algorithm>
+#include <iostream>
+
+Channel::Channel() : _name() {}
 
 Channel::Channel(const std::string &name) : _name(name) {}
 
-void    Channel::addClient(int clientFd)
+Channel &Channel::operator=(const Channel &other)
 {
-    _clients.insert(clientFd);
+	if (this != &other)
+	{
+		_name = other._name;
+		_clients = other._clients;
+		_operators = other._operators;
+		_topic = other._topic;
+		_modes = other._modes;
+		_key = other._key;
+		_inviteList = other._inviteList;
+		_userLimit = other._userLimit;
+	}
+	return *this;
 }
 
-void    Channel::removeClient(int clientFd) 
+void Channel::addClient(int clientFd)
 {
-    _clients.erase(clientFd);
-    _operators.erase(clientFd);
+	_clients.insert(clientFd);
+	std::cout << "here " << _clients.size() << std::endl;
 }
 
-void    Channel::addOperator(int clientFd) 
+void Channel::removeClient(int clientFd)
 {
-    if (_clients.count(clientFd))
-        _operators.insert(clientFd);
+	_clients.erase(clientFd);
+	_operators.erase(clientFd);
 }
 
-bool    Channel::isMember(int clientFd) const 
+void Channel::addOperator(int clientFd)
 {
-    return (_clients.count(clientFd));
+	if (_clients.count(clientFd))
+		_operators.insert(clientFd);
 }
 
-bool    Channel::isOperator(int clientFd) const 
-{
-    return (_operators.count(clientFd));
-}
+bool Channel::isMember(int clientFd) const { return (_clients.count(clientFd)); }
 
-const std::string &Channel::getName() const
-{
-	return _name;
-}
+bool Channel::isOperator(int clientFd) const { return (_operators.count(clientFd)); }
 
-const std::set<int> &Channel::getClients() const 
-{
-    return _clients;
-}
+const std::string &Channel::getName() const { return _name; }
 
-const std::string	&Channel::getTopic() const
-{
-	return _topic;
-}
+const std::set<int> &Channel::getClients() const { return _clients; }
 
-const std::string	&Channel::getModes() const
-{
-	return _modes;
-}
+const std::string &Channel::getTopic() const { return _topic; }
 
-const std::string	&Channel::getKey() const
-{
-	return _key;
-}
+const std::string &Channel::getModes() const { return _modes; }
 
-const int	&Channel::getUserLimit() const
-{
-	return _userLimit;
-}
+const std::string &Channel::getKey() const { return _key; }
 
-void	Channel::setTopic(std::string &topic)
-{
-	_topic = topic;
-}
+const int &Channel::getUserLimit() const { return _userLimit; }
 
-void	Channel::setModes(std::string &modes)
-{
-	_modes = modes;
-}
+void Channel::setTopic(std::string &topic) { _topic = topic; }
 
-void	Channel::addMode(char mode)
+void Channel::setModes(std::string &modes) { _modes = modes; }
+
+void Channel::addMode(char mode)
 {
 	if (_modes.find(mode) != std::string::npos)
 		_modes += mode;
 }
 
-void	Channel::setKey(std::string &key)
-{
-	_key = key;
-}
+void Channel::setKey(std::string &key) { _key = key; }
 
-void	Channel::setUserLimit(int limit)
-{
-	_userLimit = limit;
-}
+void Channel::setUserLimit(int limit) { _userLimit = limit; }
 
-void	Channel::removeMode(char mode)
-{
-	_modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end());
-}
+void Channel::removeMode(char mode) { _modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end()); }
 
-void	Channel::removeInvite(int clientFd)
-{
-	_inviteList.erase(clientFd);
-}
+void Channel::removeInvite(int clientFd) { _inviteList.erase(clientFd); }
 
-bool	Channel::isInvited(int clientFd) const
-{
-	return (_inviteList.find(clientFd) != _inviteList.end());
-}
+bool Channel::isInvited(int clientFd) const { return (_inviteList.find(clientFd) != _inviteList.end()); }
 
-bool	Channel::hasMode(char mode) const
-{
-	return (_modes.find(mode) != std::string::npos);
-}
+bool Channel::hasMode(char mode) const { return (_modes.find(mode) != std::string::npos); }
 
-void	Channel::addInvite(int clientFd)
-{
-	_inviteList.insert(clientFd);
-}
+void Channel::addInvite(int clientFd) { _inviteList.insert(clientFd); }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -56,7 +56,7 @@ const std::string &Channel::getModes() const { return _modes; }
 
 const std::string &Channel::getKey() const { return _key; }
 
-const int &Channel::getUserLimit() const { return _userLimit; }
+const unsigned int &Channel::getUserLimit() const { return _userLimit; }
 
 void Channel::setTopic(std::string &topic) { _topic = topic; }
 
@@ -64,13 +64,13 @@ void Channel::setModes(std::string &modes) { _modes = modes; }
 
 void Channel::addMode(char mode)
 {
-	if (_modes.find(mode) != std::string::npos)
+	if (_modes.find(mode) == std::string::npos)
 		_modes += mode;
 }
 
-void Channel::setKey(std::string &key) { _key = key; }
+void Channel::setKey(std::string key) { _key = key; }
 
-void Channel::setUserLimit(int limit) { _userLimit = limit; }
+void Channel::setUserLimit(unsigned int limit) { _userLimit = limit; }
 
 void Channel::removeMode(char mode) { _modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end()); }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -30,6 +30,11 @@ bool    Channel::isOperator(int clientFd) const
     return (_operators.count(clientFd));
 }
 
+const std::string &Channel::getName() const
+{
+	return _name;
+}
+
 const std::set<int> &Channel::getClients() const 
 {
     return _clients;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -1,240 +1,254 @@
 #include "../../includes/server/Server.hpp"
 #include "../../includes/client/Client.hpp"
 #include "../../includes/utils/Utils.hpp"
+#include <arpa/inet.h>
+#include <cerrno>
 #include <cstddef>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <netinet/in.h>
+#include <set>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <sys/socket.h>
-#include <stdexcept>
-#include <unistd.h>
 #include <sys/types.h>
-#include <netinet/in.h>
-#include <fcntl.h>
-#include <cstring>
-#include <arpa/inet.h>
-#include <iostream>
-#include <cerrno>
-#include <set>
+#include <unistd.h>
 #include <utility>
 #include <vector>
 
-Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__){
-    _port = port;
-    _password = password;
-    _serverSocketFd = -1;
-    _running = false;
+Server::Server(int port, const std::string &password)
+    : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__)
+{
+	_port = port;
+	_password = password;
+	_serverSocketFd = -1;
+	_running = false;
 	initCommandMap();
 }
 
-Server::~Server() {
-    // Will need to have the close sockets fds, free memory and delete clients later
-    if (_serverSocketFd >= 0)
-        close(_serverSocketFd);
+Server::~Server()
+{
+	// Will need to have the close sockets fds, free memory and delete clients
+	// later
+	if (_serverSocketFd >= 0)
+		close(_serverSocketFd);
 }
 
-void    Server::setupSocketOpts() {
-    // Setup the options that our server socket will have
-    int opt = 1;
-    if (setsockopt(_serverSocketFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
-        throw   std::runtime_error("Failed to set socket options");
+void Server::setupSocketOpts()
+{
+	// Setup the options that our server socket will have
+	int opt = 1;
+	if (setsockopt(_serverSocketFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+		throw std::runtime_error("Failed to set socket options");
 }
 
-void    Server::setupServerAddress() {
-    // Setup the address and port that our socket will be listening
-    sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(_port);
-    addr.sin_addr.s_addr = INADDR_ANY;
-    std::memset(addr.sin_zero, 0, sizeof(addr.sin_zero));
-    if (bind(_serverSocketFd, (struct sockaddr*)&addr, sizeof(addr)) < 0)
-        throw   std::runtime_error("Failed to bind socket port and address");
+void Server::setupServerAddress()
+{
+	// Setup the address and port that our socket will be listening
+	sockaddr_in addr;
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(_port);
+	addr.sin_addr.s_addr = INADDR_ANY;
+	std::memset(addr.sin_zero, 0, sizeof(addr.sin_zero));
+	if (bind(_serverSocketFd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+		throw std::runtime_error("Failed to bind socket port and address");
 }
 
-void    Server::setupListen() {
-    if (listen(_serverSocketFd, SOMAXCONN) < 0)
-        throw   std::runtime_error("Failed to make the socket listen");
+void Server::setupListen()
+{
+	if (listen(_serverSocketFd, SOMAXCONN) < 0)
+		throw std::runtime_error("Failed to make the socket listen");
 }
 
-void    Server::setupSocket() {
-    _serverSocketFd = socket(AF_INET, SOCK_STREAM, 0);
-    if (_serverSocketFd < 0)
-    throw   std::runtime_error("Failed to create socket");
-    setupSocketOpts();
-    setupServerAddress();
-    setupListen();
+void Server::setupSocket()
+{
+	_serverSocketFd = socket(AF_INET, SOCK_STREAM, 0);
+	if (_serverSocketFd < 0)
+		throw std::runtime_error("Failed to create socket");
+	setupSocketOpts();
+	setupServerAddress();
+	setupListen();
 }
 
-void    Server::setupNonBlocking() {
-    int flags = fcntl(_serverSocketFd, F_GETFL, 0);
-    if (flags < 0)
-        throw   std::runtime_error("Failed to get socket fd flags");
-    if (fcntl(_serverSocketFd, F_SETFL,  flags | O_NONBLOCK) < 0)
-        throw   std::runtime_error("Failed to set Non blocking on socket fd");
+void Server::setupNonBlocking()
+{
+	int flags = fcntl(_serverSocketFd, F_GETFL, 0);
+	if (flags < 0)
+		throw std::runtime_error("Failed to get socket fd flags");
+	if (fcntl(_serverSocketFd, F_SETFL, flags | O_NONBLOCK) < 0)
+		throw std::runtime_error("Failed to set Non blocking on socket fd");
 }
 
-void    Server::setupServerPoll() {
-    pollfd  serverPoll;
+void Server::setupServerPoll()
+{
+	pollfd serverPoll;
 
-    serverPoll.fd = _serverSocketFd;
-    serverPoll.events = POLLIN;
-    serverPoll.revents = 0;
-    _pollFds.push_back(serverPoll);
+	serverPoll.fd = _serverSocketFd;
+	serverPoll.events = POLLIN;
+	serverPoll.revents = 0;
+	_pollFds.push_back(serverPoll);
 }
 
-void    Server::setupPolling() {
-    setupNonBlocking();
-    setupServerPoll();
+void Server::setupPolling()
+{
+	setupNonBlocking();
+	setupServerPoll();
 }
 
-void    Server::handleNewConnection() {
-    while (true)
-    {
-		
-		struct sockaddr_in	clientAddr;
-		socklen_t			addrLen;
+void Server::handleNewConnection()
+{
+	while (true)
+	{
+
+		struct sockaddr_in clientAddr;
+		socklen_t addrLen;
 
 		addrLen = sizeof(clientAddr);
-        int clientFd = accept(_serverSocketFd, (struct sockaddr*)&clientAddr, &addrLen);
-		std::string	clientHost = inet_ntoa(clientAddr.sin_addr);
-        if (clientFd < 0)
-        {
-            if (errno == EWOULDBLOCK || errno == EAGAIN)
-                break;
-            else
-                throw std::runtime_error("Accept execution failed");
-        }
-        fcntl(clientFd, F_SETFL, O_NONBLOCK);
-        _clients.insert(std::make_pair(clientFd, Client(clientFd, clientHost)));
-        pollfd clientPollFd;
-        clientPollFd.fd = clientFd;
-        clientPollFd.events = POLLIN;
-        clientPollFd.revents = 0;
-        _pollFds.push_back(clientPollFd);
+		int clientFd = accept(_serverSocketFd, (struct sockaddr *)&clientAddr, &addrLen);
+		std::string clientHost = inet_ntoa(clientAddr.sin_addr);
+		if (clientFd < 0)
+		{
+			if (errno == EWOULDBLOCK || errno == EAGAIN)
+				break;
+			else
+				throw std::runtime_error("Accept execution failed");
+		}
+		fcntl(clientFd, F_SETFL, O_NONBLOCK);
+		_clients.insert(std::make_pair(clientFd, Client(clientFd, clientHost)));
+		pollfd clientPollFd;
+		clientPollFd.fd = clientFd;
+		clientPollFd.events = POLLIN;
+		clientPollFd.revents = 0;
+		_pollFds.push_back(clientPollFd);
 
-        std::cout << "New client Connected: FD " << clientFd << std::endl;
-    }
+		std::cout << "New client Connected: FD " << clientFd << std::endl;
+	}
 }
 
 std::vector<std::string> split(const std::string message)
 {
-	std::vector<std::string>	res;
-	std::istringstream			iss(message);
-	std::string					word;
+	std::vector<std::string> res;
+	std::istringstream iss(message);
+	std::string word;
 
 	while (iss >> word)
 		res.push_back(word);
 	return (res);
 }
 
-void    Server::processClientBuffer(Client &client)
+void Server::processClientBuffer(Client &client)
 {
 	std::string &buf = client.getInputBuffer();
-    size_t pos;
+	size_t pos;
 
-    while ((pos = buf.find("\r\n")) != std::string::npos)
-    {
-        std::string message = buf.substr(0, pos);
-        buf.erase(0, pos + 1);
+	while ((pos = buf.find("\r\n")) != std::string::npos)
+	{
+		std::string message = buf.substr(0, pos);
+		buf.erase(0, pos + 1);
 		std::vector<std::string> split_msg = split(message);
-        std::cout << "Received command: " << message << std::endl;
+		std::cout << "Received command: " << message << std::endl;
 		if (!split_msg.empty())
 		{
 			std::map<std::string, CommandHandler>::iterator it = _cmdMap.find(split_msg[0]);
 			if (it != _cmdMap.end())
 				(this->*(it->second))(client, message, split_msg);
 			else
-				sendMessage(client.getFd(), ERR_UNKNOWNCOMMAND + " " + (client.getNickname().empty() ? "*" : client.getNickname()) + " " + split_msg[0] + " :Unknown command");
+				sendMessage(client.getFd(), ERR_UNKNOWNCOMMAND + " " +
+				                                (client.getNickname().empty() ? "*" : client.getNickname()) + " " +
+				                                split_msg[0] + " :Unknown command");
 		}
-		if (!client.getIsRegistered() && client.getIsAuthenticated() 
-			&& !client.getNickname().empty() && !client.getUsername().empty())
+		if (!client.getIsRegistered() && client.getIsAuthenticated() && !client.getNickname().empty() &&
+		    !client.getUsername().empty())
 		{
 			sendWelcomeMessage(client);
 			client.setIsRegistered(true);
 		}
-    }
+	}
 }
 
-void    Server::removeClient(int clientFd)
+void Server::removeClient(int clientFd)
 {
-    close(clientFd);
-    _clients.erase(clientFd);
-    for (size_t i = 0; i < _pollFds.size(); i++)
-    {
-        if (_pollFds[i].fd == clientFd)
-        {
-            _pollFds.erase(_pollFds.begin() + i);
-            break;
-        }
-    }
+	close(clientFd);
+	_clients.erase(clientFd);
+	for (size_t i = 0; i < _pollFds.size(); i++)
+	{
+		if (_pollFds[i].fd == clientFd)
+		{
+			_pollFds.erase(_pollFds.begin() + i);
+			break;
+		}
+	}
 }
 
-void    Server::sendMessage(int clientFd, const std::string &message)
+void Server::sendMessage(int clientFd, const std::string &message)
 {
-    std::string formatted = message + "\r\n";
-    ssize_t bytes_send;
+	std::string formatted = message + "\r\n";
+	ssize_t bytes_send;
 
-    bytes_send = send(clientFd, formatted.c_str(), formatted.size(), 0);
-    if (bytes_send < 0)
-        std::cerr << "Send failed to client fd: " << clientFd << std::endl;
+	bytes_send = send(clientFd, formatted.c_str(), formatted.size(), 0);
+	if (bytes_send < 0)
+		std::cerr << "Send failed to client fd: " << clientFd << std::endl;
 }
 
-void	Server::sendWelcomeMessage(Client &client)
+void Server::sendWelcomeMessage(Client &client)
 {
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_WELCOME
-		+ " " + client.getNickname() + " :Welcome to our IRC network "
-		+ client.getNickname() + "!" + client.getUsername() + "@" + client.getHost());
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_YOURHOST
-		+ " " + client.getNickname() + " :Your host is " + _serverName + ", running version " + _version);
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CREATED
-		+ " " + client.getNickname() + " :This server was created at " + _creationDate);
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_MYINFO
-		+ " " + client.getNickname() + " " + _serverName + " " + _version + " o o");
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_WELCOME + " " + client.getNickname() +
+	                                " :Welcome to our IRC network " + client.getNickname() + "!" +
+	                                client.getUsername() + "@" + client.getHost());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_YOURHOST + " " + client.getNickname() +
+	                                " :Your host is " + _serverName + ", running version " + _version);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CREATED + " " + client.getNickname() +
+	                                " :This server was created at " + _creationDate);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_MYINFO + " " + client.getNickname() + " " + _serverName +
+	                                " " + _version + " o o");
 }
 
-void    Server::broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd)
+void Server::broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd)
 {
-    std::map<std::string, Channel>::iterator it = _channels.find(channelName);
+	std::map<std::string, Channel>::iterator it = _channels.find(channelName);
 
-    if (it == _channels.end())
-        return;
-    const std::set<int> &clients = it->second.getClients();
-    for (std::set<int>::const_iterator index = clients.begin(); index != clients.end(); ++index)
-    {
-        if (*index == excludeFd)
-            continue;
-        sendMessage(*index, message);
-    }
+	if (it == _channels.end())
+		return;
+	const std::set<int> &clients = it->second.getClients();
+	for (std::set<int>::const_iterator index = clients.begin(); index != clients.end(); ++index)
+	{
+		if (*index == excludeFd)
+			continue;
+		sendMessage(*index, message);
+	}
 }
 
-void	Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::string	res;
-	
+	std::string res;
+
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PASS " + MSG_NEEDMOREPARAMS);
-		return ;
+		return;
 	}
 	res = authPass(client, tokens[1], _password);
 	if (res.compare(ERR_ALREADYREGISTRED) == 0)
 		sendMessage(client.getFd(), ERR_ALREADYREGISTRED + " PASS " + ":You may not reregister");
 	if (res.compare(ERR_PASSWDMISMATCH) == 0)
 	{
-	 	sendMessage(client.getFd(), ERR_PASSWDMISMATCH + " PASS " + ":Password incorrect");
+		sendMessage(client.getFd(), ERR_PASSWDMISMATCH + " PASS " + ":Password incorrect");
 		removeClient(client.getFd());
 	}
 }
 
-void	Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::handleNick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::string	res;
+	std::string res;
 
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " NICK " + MSG_NEEDMOREPARAMS);
-		return ;
+		return;
 	}
 	res = setClientNick(tokens[1], client, _clients);
 	if (res.compare(ERR_ERRONEUSNICKNAME) == 0)
@@ -243,15 +257,15 @@ void	Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 		sendMessage(client.getFd(), ERR_NICKNAMEINUSE + " NICK " + ":Nickname is already in use");
 }
 
-void	Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::string	res;
+	std::string res;
 
 	res = setClientUsername(rawMsg, tokens, client);
 	if (tokens.size() < 5)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + MSG_NEEDMOREPARAMS);
-		return ;
+		return;
 	}
 	if (res.compare(ERR_INVALIDUSERNAME) == 0)
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid username");
@@ -263,15 +277,16 @@ void	Server::handleUser(Client &client, const std::string &rawMsg, const std::ve
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid realname");
 }
 
-std::string	Server::showClientsInChannel(Channel &channel)
+std::string Server::showClientsInChannel(Channel &channel)
 {
-	std::string	names;
+	std::string names;
 
 	for (std::set<int>::iterator it = channel.getClients().begin(); it != channel.getClients().end(); ++it)
 	{
+
 		std::set<int>::iterator next_it = it;
 		++next_it;
-		std::map<int, Client>::iterator client_it =_clients.find(*it);
+		std::map<int, Client>::iterator client_it = _clients.find(*it);
 		std::cout << client_it->second.getNickname();
 		names += client_it->second.getNickname();
 		if (next_it != channel.getClients().end())
@@ -280,58 +295,68 @@ std::string	Server::showClientsInChannel(Channel &channel)
 	return names;
 }
 
-void	Server::handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::sendJoinMessage(Client &client, Channel &channel)
 {
-	std::string	res;
+	sendMessage(client.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() +
+	                                " JOIN " + ":" + channel.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC + " " + client.getNickname() + " " +
+	                                channel.getName() + " " + ":No topic is set");
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY + " " + client.getNickname() + " = " +
+	                                channel.getName() + " " + ":" + showClientsInChannel(channel));
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES + " " + client.getNickname() + " " +
+	                                channel.getName() + " :End of /NAMES list.");
+}
+
+void Server::handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	std::string res;
 
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " JOIN " + MSG_NEEDMOREPARAMS);
-		return ;
+		return;
 	}
 	bool isNewChannel = _channels.find(tokens[1]) != _channels.end() ? true : false;
 	res = joinChannel(client, tokens[1], isNewChannel);
-	
+
 	if (res.compare(ERR_NOSUCHCHANNEL) == 0)
 	{
 		sendMessage(client.getFd(), ERR_NOSUCHCHANNEL + " JOIN " + ":No such channel");
-		return ;
+		return;
 	}
-	Channel channel(tokens[1]);
+
+	std::map<std::string, Channel>::iterator it = _channels.find(tokens[1]);
+
+	if (it == _channels.end())
+		it = _channels.insert(std::pair<std::string, Channel>(tokens[1], Channel(tokens[1]))).first;
+
+	Channel &channel = it->second;
 	channel.addClient(client.getFd());
-	_channels.insert(std::pair<std::string, Channel>(tokens[1], channel));
-	sendMessage(client.getFd(), ":"
-		+ client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + ":" + channel.getName());
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC 
-		+ " " + client.getNickname() + " " + channel.getName() + " " + ":No topic is set");
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY
-		+ " " + client.getNickname() + " = " + channel.getName() + " " + ":"  + showClientsInChannel(channel));
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES
-		+ " " + client.getNickname() + " " + channel.getName() + " :End of /NAMES list.");
+	sendJoinMessage(client, channel);
 }
 
-void	Server::handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	(void)rawMsg;
 	(void)tokens;
 	std::cout << "Ignoring CAP command from FD: " << client.getFd() << std::endl;
-	return ;
+	return;
 }
 
-void	Server::handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+void Server::handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PING " + MSG_NEEDMOREPARAMS);
-		return ;
+		return;
 	}
 	size_t pos = rawMsg.find_first_of(":");
 	if (pos != std::string::npos)
 		sendMessage(client.getFd(), "PONG " + rawMsg.substr(pos));
 	else
 	{
-		std::string	msg;
+		std::string msg;
 		std::vector<std::string>::const_iterator last = tokens.end();
 		last++;
 		for (std::vector<std::string>::const_iterator it = tokens.begin() + 1; it != tokens.end(); ++it)
@@ -344,7 +369,7 @@ void	Server::handlePing(Client &client, const std::string &rawMsg, const std::ve
 	}
 }
 
-void	Server::initCommandMap()
+void Server::initCommandMap()
 {
 	_cmdMap["PASS"] = &Server::handlePass;
 	_cmdMap["NICK"] = &Server::handleNick;
@@ -354,59 +379,61 @@ void	Server::initCommandMap()
 	_cmdMap["PING"] = &Server::handlePing;
 }
 
-void    Server::handleClientData(int clientFd)
+void Server::handleClientData(int clientFd)
 {
-    char    buffer[512];
-    ssize_t bytes = recv(clientFd, buffer, sizeof(buffer), 0);
+	char buffer[512];
+	ssize_t bytes = recv(clientFd, buffer, sizeof(buffer), 0);
 
-    if (bytes > 0)
-        buffer[bytes] = '\0';
-    else if (bytes == 0)
-    {
-        std::cout << "Client disconnected\n";
-        removeClient(clientFd);
-        return ;
-    }
-    std::map<int, Client>::iterator it = _clients.find(clientFd);
-    if (it == _clients.end())
-    {
-        std::cerr << "Client not found!" << std::endl;
-        return ;
-    }
-    Client &client = it->second;
-    client.getInputBuffer().append(buffer, bytes);
-    processClientBuffer(client);
+	if (bytes > 0)
+		buffer[bytes] = '\0';
+	else if (bytes == 0)
+	{
+		std::cout << "Client disconnected\n";
+		removeClient(clientFd);
+		return;
+	}
+	std::map<int, Client>::iterator it = _clients.find(clientFd);
+	if (it == _clients.end())
+	{
+		std::cerr << "Client not found!" << std::endl;
+		return;
+	}
+	Client &client = it->second;
+	client.getInputBuffer().append(buffer, bytes);
+	processClientBuffer(client);
 }
 
-void    Server::runPollLoop() {
-    while (true)
-    {
-        int ready = poll(_pollFds.data(),_pollFds.size(), -1);
-        if (ready < 0)
-            throw std::runtime_error("Poll execution failed");
-        for (size_t i = 0; i < _pollFds.size() && ready > 0; i++)
-        {
-            if (_pollFds[i].revents == 0)
-                continue;
-            if (_pollFds[i].revents & POLLIN)
-            {
-                if (_pollFds[i].fd == _serverSocketFd)
-                {
-                    // Accept new client
-                    handleNewConnection();
-                }
-                else
-                {
-                    // Receive data from client
-                    handleClientData(_pollFds[i].fd);
-                }
-            }
-        }
-    }
+void Server::runPollLoop()
+{
+	while (true)
+	{
+		int ready = poll(_pollFds.data(), _pollFds.size(), -1);
+		if (ready < 0)
+			throw std::runtime_error("Poll execution failed");
+		for (size_t i = 0; i < _pollFds.size() && ready > 0; i++)
+		{
+			if (_pollFds[i].revents == 0)
+				continue;
+			if (_pollFds[i].revents & POLLIN)
+			{
+				if (_pollFds[i].fd == _serverSocketFd)
+				{
+					// Accept new client
+					handleNewConnection();
+				}
+				else
+				{
+					// Receive data from client
+					handleClientData(_pollFds[i].fd);
+				}
+			}
+		}
+	}
 }
 
-void    Server::start() {
-    setupSocket();
-    setupPolling();
-    runPollLoop();
+void Server::start()
+{
+	setupSocket();
+	setupPolling();
+	runPollLoop();
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -327,6 +327,11 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	bool isNewChannel = _channels.find(tokens[1]) != _channels.end() ? true : false;
 	res = joinChannel(client, tokens[1], isNewChannel);
 
+	if (res.compare(ERR_NOTREGISTERED) == 0)
+	{
+		sendMessage(client.getFd(), ERR_NOTREGISTERED + " JOIN " + ":Not registered");
+		return;
+	}
 	if (res.compare(ERR_NOSUCHCHANNEL) == 0)
 	{
 		sendMessage(client.getFd(), ERR_NOSUCHCHANNEL + " JOIN " + ":No such channel");
@@ -334,7 +339,6 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	}
 
 	std::map<std::string, Channel>::iterator it = _channels.find(tokens[1]);
-
 	if (it == _channels.end())
 	{
 		it = _channels.insert(std::pair<std::string, Channel>(tokens[1], Channel(tokens[1]))).first;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -316,9 +316,11 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 {
 	std::string res;
 	bool isNew;
+	bool isKeyPass;
 
 	(void)rawMsg;
 	isNew = false;
+	isKeyPass = false;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " JOIN " + MSG_NEEDMOREPARAMS);
@@ -346,6 +348,27 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	}
 
 	Channel &channel = it->second;
+
+	if (tokens.size() >= 3)
+		isKeyPass = channel.getKey().compare(tokens[2]) == 0;
+
+	res = checkChannelMode(channel, client.getFd(), isKeyPass);
+	if (res.compare(ERR_CHANNELISFULL) == 0)
+	{
+		sendMessage(client.getFd(), res + " JOIN " + ":Channel is full");
+		return;
+	}
+	if (res.compare(ERR_INVITEONLYCHAN) == 0)
+	{
+		sendMessage(client.getFd(), ERR_INVITEONLYCHAN + " JOIN " + ":Client not invited");
+		return;
+	}
+	if (res.compare(ERR_BADCHANNELKEY) == 0)
+	{
+		sendMessage(client.getFd(), ERR_BADCHANNELKEY + " JOIN " + ":Wrong key");
+		return;
+	}
+
 	channel.addClient(client.getFd());
 	if (isNew)
 		channel.addOperator(client.getFd());

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -274,7 +274,6 @@ std::string	Server::showClientsInChannel(Channel &channel)
 		std::map<int, Client>::iterator client_it =_clients.find(*it);
 		std::cout << client_it->second.getNickname();
 		names += client_it->second.getNickname();
-		std::cout << "----> " << client_it->second.getNickname() << std::endl;
 		if (next_it != channel.getClients().end())
 			names += " ";
 	}
@@ -291,17 +290,25 @@ void	Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " JOIN " + MSG_NEEDMOREPARAMS);
 		return ;
 	}
-	// bool isNewChannel = _channels.find(tokens[1]) != _channels.end() ? true : false;
-	// res = joinChannel(client, tokens[1], isNewChannel);	
+	bool isNewChannel = _channels.find(tokens[1]) != _channels.end() ? true : false;
+	res = joinChannel(client, tokens[1], isNewChannel);
 	
+	if (res.compare(ERR_NOSUCHCHANNEL) == 0)
+	{
+		sendMessage(client.getFd(), ERR_NOSUCHCHANNEL + " JOIN " + ":No such channel");
+		return ;
+	}
 	Channel channel(tokens[1]);
 	channel.addClient(client.getFd());
 	_channels.insert(std::pair<std::string, Channel>(tokens[1], channel));
-	
-	sendMessage(client.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + ":" + channel.getName());
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC + " " + client.getNickname() + " " + channel.getName() + " " + ":No topic is set");
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY + " " + client.getNickname() + " = " + channel.getName() + " " + ":"  + showClientsInChannel(channel));
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES + " " + client.getNickname() + " " + channel.getName() + " :End of /NAMES list.");
+	sendMessage(client.getFd(), ":"
+		+ client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + ":" + channel.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC 
+		+ " " + client.getNickname() + " " + channel.getName() + " " + ":No topic is set");
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY
+		+ " " + client.getNickname() + " = " + channel.getName() + " " + ":"  + showClientsInChannel(channel));
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES
+		+ " " + client.getNickname() + " " + channel.getName() + " :End of /NAMES list.");
 }
 
 void	Server::handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -287,6 +287,11 @@ std::string Server::showClientsInChannel(Channel &channel)
 		std::set<int>::iterator next_it = it;
 		++next_it;
 		std::map<int, Client>::iterator client_it = _clients.find(*it);
+
+		std::set<int>::iterator op_it = channel.getOperators().find(*it);
+		if (op_it != channel.getOperators().end())
+			names += "@";
+
 		std::cout << client_it->second.getNickname();
 		names += client_it->second.getNickname();
 		if (next_it != channel.getClients().end())
@@ -310,8 +315,10 @@ void Server::sendJoinMessage(Client &client, Channel &channel)
 void Server::handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::string res;
+	bool isNew;
 
 	(void)rawMsg;
+	isNew = false;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " JOIN " + MSG_NEEDMOREPARAMS);
@@ -329,10 +336,15 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	std::map<std::string, Channel>::iterator it = _channels.find(tokens[1]);
 
 	if (it == _channels.end())
+	{
 		it = _channels.insert(std::pair<std::string, Channel>(tokens[1], Channel(tokens[1]))).first;
+		isNew = true;
+	}
 
 	Channel &channel = it->second;
 	channel.addClient(client.getFd());
+	if (isNew)
+		channel.addOperator(client.getFd());
 	sendJoinMessage(client, channel);
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <cerrno>
 #include <set>
+#include <utility>
 
 Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__){
     _port = port;
@@ -261,11 +262,53 @@ void	Server::handleUser(Client &client, const std::string &rawMsg, const std::ve
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + ":invalid realname");
 }
 
+std::string	Server::showClientsInChannel(Channel &channel)
+{
+	std::string	names;
+
+	for (std::set<int>::iterator it = channel.getClients().begin(); it != channel.getClients().end(); ++it)
+	{
+		std::set<int>::iterator next_it = it;
+		++next_it;
+		std::map<int, Client>::iterator client_it =_clients.find(*it);
+		std::cout << client_it->second.getNickname();
+		names += client_it->second.getNickname();
+		std::cout << "----> " << client_it->second.getNickname() << std::endl;
+		if (next_it != channel.getClients().end())
+			names += " ";
+	}
+	return names;
+}
+
+void	Server::handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	std::string	res;
+
+	(void)rawMsg;
+	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " JOIN " + MSG_NEEDMOREPARAMS);
+		return ;
+	}
+	// bool isNewChannel = _channels.find(tokens[1]) != _channels.end() ? true : false;
+	// res = joinChannel(client, tokens[1], isNewChannel);	
+	
+	Channel channel(tokens[1]);
+	channel.addClient(client.getFd());
+	_channels.insert(std::pair<std::string, Channel>(tokens[1], channel));
+	
+	sendMessage(client.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + ":" + channel.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC + " " + client.getNickname() + " " + channel.getName() + " " + ":No topic is set");
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY + " " + client.getNickname() + " = " + channel.getName() + " " + ":"  + showClientsInChannel(channel));
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES + " " + client.getNickname() + " " + channel.getName() + " :End of /NAMES list.");
+}
+
 void	Server::initCommandMap()
 {
 	_cmdMap["PASS"] = &Server::handlePass;
 	_cmdMap["NICK"] = &Server::handleNick;
 	_cmdMap["USER"] = &Server::handleUser;
+	_cmdMap["JOIN"] = &Server::handleJoin;
 }
 
 void    Server::handleClientData(int clientFd)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -18,8 +18,7 @@
 #include <utility>
 #include <vector>
 
-Server::Server(int port, const std::string &password)
-    : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__)
+Server::Server(int port, const std::string &password) : _serverName("ircat"), _version("0.5"), _creationDate(std::string(__DATE__) + " " + __TIME__)
 {
 	_port = port;
 	_password = password;
@@ -155,12 +154,9 @@ void Server::processClientBuffer(Client &client)
 			if (it != _cmdMap.end())
 				(this->*(it->second))(client, message, split_msg);
 			else
-				sendMessage(client.getFd(), ERR_UNKNOWNCOMMAND + " " +
-				                                (client.getNickname().empty() ? "*" : client.getNickname()) + " " +
-				                                split_msg[0] + " :Unknown command");
+				sendMessage(client.getFd(), ERR_UNKNOWNCOMMAND + " " + (client.getNickname().empty() ? "*" : client.getNickname()) + " " + split_msg[0] + " :Unknown command");
 		}
-		if (!client.getIsRegistered() && client.getIsAuthenticated() && !client.getNickname().empty() &&
-		    !client.getUsername().empty())
+		if (!client.getIsRegistered() && client.getIsAuthenticated() && !client.getNickname().empty() && !client.getUsername().empty())
 		{
 			sendWelcomeMessage(client);
 			client.setIsRegistered(true);
@@ -194,15 +190,10 @@ void Server::sendMessage(int clientFd, const std::string &message)
 
 void Server::sendWelcomeMessage(Client &client)
 {
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_WELCOME + " " + client.getNickname() +
-	                                " :Welcome to our IRC network " + client.getNickname() + "!" +
-	                                client.getUsername() + "@" + client.getHost());
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_YOURHOST + " " + client.getNickname() +
-	                                " :Your host is " + _serverName + ", running version " + _version);
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CREATED + " " + client.getNickname() +
-	                                " :This server was created at " + _creationDate);
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_MYINFO + " " + client.getNickname() + " " + _serverName +
-	                                " " + _version + " o o");
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_WELCOME + " " + client.getNickname() + " :Welcome to our IRC network " + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_YOURHOST + " " + client.getNickname() + " :Your host is " + _serverName + ", running version " + _version);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CREATED + " " + client.getNickname() + " :This server was created at " + _creationDate);
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_MYINFO + " " + client.getNickname() + " " + _serverName + " " + _version + " o o");
 }
 
 void Server::broadcastToChannel(const std::string &channelName, const std::string &message, int excludeFd)
@@ -302,14 +293,10 @@ std::string Server::showClientsInChannel(Channel &channel)
 
 void Server::sendJoinMessage(Client &client, Channel &channel)
 {
-	sendMessage(client.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() +
-	                                " JOIN " + ":" + channel.getName());
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC + " " + client.getNickname() + " " +
-	                                channel.getName() + " " + ":No topic is set");
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY + " " + client.getNickname() + " = " +
-	                                channel.getName() + " " + ":" + showClientsInChannel(channel));
-	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES + " " + client.getNickname() + " " +
-	                                channel.getName() + " :End of /NAMES list.");
+	sendMessage(client.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " JOIN " + ":" + channel.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NOTOPIC + " " + client.getNickname() + " " + channel.getName() + " " + (channel.getTopic().empty() ? ":No topic is set" : channel.getTopic()));
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_NAMREPLY + " " + client.getNickname() + " = " + channel.getName() + " " + ":" + showClientsInChannel(channel));
+	sendMessage(client.getFd(), ":" + _serverName + " " + RPL_ENDOFNAMES + " " + client.getNickname() + " " + channel.getName() + " :End of /NAMES list.");
 }
 
 void Server::handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
@@ -348,7 +335,6 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	}
 
 	Channel &channel = it->second;
-
 	if (tokens.size() >= 3)
 		isKeyPass = channel.getKey().compare(tokens[2]) == 0;
 


### PR DESCRIPTION
Closes #36

Implement JOIN command with:
- Channel creation and operator assignment
- Key-based access control (+k mode)
- Channel capacity limits (+l mode)
- Invite-only mode (+i support)
- Proper name list with operator prefixes (@)
- All required numeric replies (461, 471, 473, 475, 332, 353, 366)