### PR TITLE
feat(mode): implement MODE command for channel mode management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ CPP = c++
 FLAGS = -Wall -Werror -Wextra -std=c++98
 	   
 SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp src/server/Channel.cpp \
-src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp
+src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp \
+src/commands/MODE.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -49,8 +49,7 @@ class Channel
 	void removeMode(char mode);
 	void removeInvite(int clientFd);
 	void removeClient(int clientFd);
-  void removeOperator(int clientFd);
-	
+	void removeOperator(int clientFd);
 };
 
 #endif

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -32,6 +32,7 @@ class Channel
 	const unsigned int &getUserLimit() const;
 	const bool &isInviteOnly() const;
 	const bool &isTopicProtected() const;
+	const std::string getUserLimitStr() const;
 	
 	void setTopic(std::string topic);
 	void setModes(std::string &modes);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -15,6 +15,8 @@ class Channel
 	std::string _key;
 	std::set<int> _inviteList;
 	unsigned int _userLimit;
+	bool	_inviteOnly;
+	bool	_topicProtected;
 
   public:
 	Channel();
@@ -28,13 +30,15 @@ class Channel
 	const std::string &getModes() const;
 	const std::string &getKey() const;
 	const unsigned int &getUserLimit() const;
+	const bool isInviteOnly() const;
+	const bool isTopicProtected() const;
 	
-	// std::set<int> &getOperators();
-
 	void setTopic(std::string topic);
 	void setModes(std::string &modes);
 	void setKey(std::string key);
 	void setUserLimit(unsigned int limit);
+	void setInviteOnly(bool mode);
+	void setTopicProtected(bool mode);
 
 	void addClient(int clientFd);
 	void addOperator(int clientFd);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -28,6 +28,8 @@ class Channel
 	const std::string &getModes() const;
 	const std::string &getKey() const;
 	const unsigned int &getUserLimit() const;
+	
+	// std::set<int> &getOperators();
 
 	void setTopic(std::string topic);
 	void setModes(std::string &modes);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -15,8 +15,8 @@ class Channel
 	std::string _key;
 	std::set<int> _inviteList;
 	unsigned int _userLimit;
-	bool	_inviteOnly;
-	bool	_topicProtected;
+	bool _inviteOnly;
+	bool _topicProtected;
 
   public:
 	Channel();
@@ -33,7 +33,7 @@ class Channel
 	const bool &isInviteOnly() const;
 	const bool &isTopicProtected() const;
 	const std::string getUserLimitStr() const;
-	
+
 	void setTopic(std::string topic);
 	void setModes(std::string &modes);
 	void setKey(std::string key);
@@ -44,14 +44,14 @@ class Channel
 	void addClient(int clientFd);
 	void addOperator(int clientFd);
 	void addInvite(int clientFd);
-	void addMode(char mode);
+	bool addMode(char mode);
 
 	bool isMember(int clientFd) const;
 	bool isOperator(int clientFd) const;
 	bool isInvited(int clientFd) const;
 	bool hasMode(char mode) const;
 
-	void removeMode(char mode);
+	bool removeMode(char mode);
 	void removeInvite(int clientFd);
 	void removeClient(int clientFd);
 	void removeOperator(int clientFd);

--- a/includes/server/Channel.hpp
+++ b/includes/server/Channel.hpp
@@ -30,8 +30,8 @@ class Channel
 	const std::string &getModes() const;
 	const std::string &getKey() const;
 	const unsigned int &getUserLimit() const;
-	const bool isInviteOnly() const;
-	const bool isTopicProtected() const;
+	const bool &isInviteOnly() const;
+	const bool &isTopicProtected() const;
 	
 	void setTopic(std::string topic);
 	void setModes(std::string &modes);

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -54,7 +54,7 @@ class Server
 	void handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	bool checkForParams(Client &client, std::string commmand, unsigned int size);
 	void sendJoinMessage(Client &client, Channel &channel);
-	void sendError(Client &client, const std::string &command, const std::string &errorCode);
+	void sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra);
 	std::string showClientsInChannel(Channel &channel);
 
   public:

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -56,6 +56,7 @@ class Server
 	void sendJoinMessage(Client &client, Channel &channel);
 	void sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra);
 	std::string showClientsInChannel(Channel &channel);
+	std::string showChannelModes(Channel &channel);
 
   public:
 	// Constructors

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -51,6 +51,7 @@ class Server
 	void handleJoin(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	bool checkForParams(Client &client, std::string commmand, unsigned int size);
 	void sendJoinMessage(Client &client, Channel &channel);
 	void sendError(Client &client, const std::string &command, const std::string &errorCode);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -40,7 +40,7 @@ const std::string RPL_ENDOFNAMES = "366";
 const std::string RPL_CHANNELMODEIS = "324";
 
 /* Channel error replies */
-const std::string ERR_UNKNOWNERROR = "400"; 
+const std::string ERR_UNKNOWNERROR = "400";
 const std::string ERR_NOSUCHNICK = "401";
 const std::string ERR_NOSUCHCHANNEL = "403";
 const std::string ERR_CANNOTSENDTOCHAN = "404";
@@ -62,6 +62,6 @@ std::string setClientNick(std::string nickname, Client &client, std::map<int, Cl
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator);
+std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -61,5 +61,6 @@ std::string setClientNick(std::string nickname, Client &client, std::map<int, Cl
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
+std::string	manageChannelMode(const Channel &channel, const std::string modes, const std::vector<std::string> params);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -62,6 +62,6 @@ std::string setClientNick(std::string nickname, Client &client, std::map<int, Cl
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isOperator);
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isMember, bool isOperator);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -40,7 +40,8 @@ const std::string RPL_ENDOFNAMES = "366";
 const std::string RPL_CHANNELMODEIS = "324";
 
 /* Channel error replies */
-const std::string RR_NOSUCHNICK = "401";
+const std::string ERR_UNKNOWNERROR = "400"; 
+const std::string ERR_NOSUCHNICK = "401";
 const std::string ERR_NOSUCHCHANNEL = "403";
 const std::string ERR_CANNOTSENDTOCHAN = "404";
 const std::string ERR_TOOMANYCHANNELS = "405";
@@ -61,6 +62,6 @@ std::string setClientNick(std::string nickname, Client &client, std::map<int, Cl
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
-std::string	manageChannelMode(const Channel &channel, const std::string modes, const std::vector<std::string> params);
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isOperator);
 
 #endif

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -62,6 +62,6 @@ std::string setClientNick(std::string nickname, Client &client, std::map<int, Cl
 std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isMember, bool isOperator);
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator);
 
 #endif

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -32,12 +32,12 @@ void	solveTopicMode(Channel &channel, char mode, bool isAddMode)
 
 void	solveKeyMode(Channel &channel, char mode, std::string key, bool isAddMode)
 {
-	if (isAddMode)
+	if (isAddMode && channel.getKey().empty())
 	{
 		channel.setKey(key);
 		channel.addMode(mode);
 	}
-	else 
+	else if (!isAddMode) 
 	{
 		channel.setKey("");
 		channel.removeMode(mode);

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -34,7 +34,7 @@ void	addUserLimit(Channel &channel, unsigned int limit)
 	channel.setUserLimit(limit);
 }
 
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isOperator)
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isMember, bool isOperator)
 {
 	std::vector<std::string>::iterator paramIt;
 	std::string	validModes = "+-itkol";
@@ -44,6 +44,8 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 	paramIt = params.begin();
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
+	if (!isMember)
+		return ERR_NOTONCHANNEL;
 	if (isOperator)
 	{
 		if (modes.find_first_not_of(validModes) != std::string::npos)

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -2,73 +2,87 @@
 #include <iostream>
 #include <sstream>
 
-void	solveInviteMode(Channel &channel, char mode, bool isAddMode)
+bool solveInviteMode(Channel &channel, char mode, bool isAddMode)
 {
 	if (isAddMode)
 	{
 		channel.setInviteOnly(true);
-		channel.addMode(mode);
+		return (channel.addMode(mode));
 	}
-	else 
+	else
 	{
 		channel.setInviteOnly(false);
-		channel.removeMode(mode);
+		return (channel.removeMode(mode));
 	}
 }
 
-void	solveTopicMode(Channel &channel, char mode, bool isAddMode)
+bool solveTopicMode(Channel &channel, char mode, bool isAddMode)
 {
 	if (isAddMode)
 	{
 		channel.setTopicProtected(true);
-		channel.addMode(mode);
+		return (channel.addMode(mode));
 	}
 	else
 	{
 		channel.setTopicProtected(false);
-		channel.removeMode(mode);
+		return (channel.removeMode(mode));
 	}
 }
 
-void	solveKeyMode(Channel &channel, char mode, std::string key, bool isAddMode)
+bool solveKeyMode(Channel &channel, char mode, std::string key, bool isAddMode)
 {
 	if (isAddMode && channel.getKey().empty())
 	{
 		channel.setKey(key);
-		channel.addMode(mode);
+		return (channel.addMode(mode));
 	}
-	else if (!isAddMode) 
+	else if (!isAddMode)
 	{
 		channel.setKey("");
-		channel.removeMode(mode);
+		return (channel.removeMode(mode));
 	}
+	return false;
 }
 
-void	solveOperatorMode(Channel &channel, Client client, bool isAddMode)
-{
-	isAddMode ? channel.addOperator(client.getFd()) : channel.removeOperator(client.getFd());
-}
-
-void	removeOperator(Channel &channel, Client client)
-{
-	channel.removeOperator(client.getFd());
-}
-
-void	solveLimitMode(Channel &channel, char mode, unsigned int limit, bool isAddMode)
+bool solveOperatorMode(Channel &channel, Client client, bool isAddMode)
 {
 	if (isAddMode)
 	{
-		channel.setUserLimit(limit);
-		channel.addMode(mode);
+		if (!channel.isOperator(client.getFd()))
+		{
+			channel.addOperator(client.getFd());
+			return true;
+		}
 	}
 	else
 	{
-		channel.setUserLimit(0);
-		channel.removeMode(mode);
+		if (channel.isOperator(client.getFd()))
+		{
+			channel.removeOperator(client.getFd());
+			return true;
+		}
 	}
+	return false;
 }
 
-std::map<int, Client>::iterator	findClientByNick(std::map<int, Client> &clients, std::string &nick)
+bool solveLimitMode(Channel &channel, char mode, unsigned int limit, bool isAddMode)
+{
+	if (isAddMode)
+	{
+		if (channel.getUserLimit() != limit)
+		{
+			channel.setUserLimit(limit);
+			channel.addMode(mode);
+			return true;
+		}
+		return false;
+	}
+	channel.setUserLimit(0);
+	return (channel.removeMode(mode));
+}
+
+std::map<int, Client>::iterator findClientByNick(std::map<int, Client> &clients, std::string &nick)
 {
 	std::map<int, Client>::iterator it;
 
@@ -80,16 +94,16 @@ std::map<int, Client>::iterator	findClientByNick(std::map<int, Client> &clients,
 	return it;
 }
 
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator)
+std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange)
 {
-	bool								addMode;
-	unsigned int						limit;
-	std::string							validModes;
-	std::stringstream					iss;
-	std::map<int, Client>::iterator		clientIt;
-	std::vector<std::string>::iterator	paramIt;
+	bool addMode;
+	unsigned int limit;
+	std::string validModes;
+	std::stringstream iss;
+	std::map<int, Client>::iterator clientIt;
+	std::vector<std::string>::iterator paramIt;
+	std::string paramChange;
 
-	addMode = false;
 	limit = 0;
 	paramIt = params.begin();
 	validModes = "itkol";
@@ -98,19 +112,28 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 	if (!isMember)
 		return ERR_NOTONCHANNEL;
 
+	bool changeFlag;
+
 	if (isOperator)
 	{
 		if (modes.at(0) != '+' && modes.at(0) != '-')
 			return ERR_UNKNOWNMODE + " " + modes.at(0);
+		addMode = modes.at(0) == '+' ? false : true;
 		for (std::string::iterator it = modes.begin(); it != modes.end(); ++it)
 		{
 			if (*it == '+')
 			{
+				if (!addMode)
+					changeFlag = true;
+				// modeChange += '+';
 				addMode = true;
 				continue;
 			}
 			if (*it == '-')
 			{
+				if (addMode)
+					changeFlag = true;
+				// modeChange += '-';
 				addMode = false;
 				continue;
 			}
@@ -118,45 +141,90 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 			{
 				switch (*it)
 				{
-					case 'i':
-						solveInviteMode(channel, *it, addMode);
-						break;
-					case 't':
-						solveTopicMode(channel, *it, addMode);
-						break;
-					case 'k':
-						if (params.size() == 0 || paramIt == params.end())
-							return ERR_NEEDMOREPARAMS;
-						solveKeyMode(channel, *it, *paramIt, addMode);
-						++paramIt;
-						break;
-					case 'o':
-						if (params.size() == 0 || paramIt == params.end())
-							return ERR_NEEDMOREPARAMS;
-						clientIt = findClientByNick(clients, *paramIt);
-						if (clientIt == clients.end())
-							return ERR_NOSUCHNICK;
-						if (!channel.isMember(clientIt->second.getFd()))
-							return ERR_USERNOTINCHANNEL;
-						solveOperatorMode(channel, clientIt->second, addMode);
-						++paramIt;
-						break;
-					case 'l':
-						if (addMode && (params.size() == 0 || paramIt == params.end()))
-							return ERR_NEEDMOREPARAMS;
-						else if (addMode)
+				case 'i':
+					if (solveInviteMode(channel, *it, addMode))
+					{
+						if (changeFlag)
 						{
-							iss.clear();
-							iss.str(*paramIt);
-							iss >> limit;
-							if (!iss.eof() || paramIt->at(0) == '-')
-								return ERR_UNKNOWNERROR;
+							modeChange += addMode ? '+' : '-';
+							changeFlag = false;
 						}
-						solveLimitMode(channel, *it, limit, addMode);
+						modeChange += *it;
+					}
+					break;
+				case 't':
+					if (solveTopicMode(channel, *it, addMode))
+					{
+						if (changeFlag)
+						{
+							modeChange += addMode ? '+' : '-';
+							changeFlag = false;
+						}
+						modeChange += *it;
+					}
+					break;
+				case 'k':
+					if (params.size() == 0 || paramIt == params.end())
+						return ERR_NEEDMOREPARAMS;
+					if (solveKeyMode(channel, *it, *paramIt, addMode))
+					{
+						if (changeFlag)
+						{
+							modeChange += addMode ? '+' : '-';
+							changeFlag = false;
+						}
+						modeChange += *it;
+						paramChange += ' ' + *paramIt;
+					}
+					++paramIt;
+					break;
+				case 'o':
+					if (params.size() == 0 || paramIt == params.end())
+						return ERR_NEEDMOREPARAMS;
+					clientIt = findClientByNick(clients, *paramIt);
+					if (clientIt == clients.end())
+						return ERR_NOSUCHNICK;
+					if (!channel.isMember(clientIt->second.getFd()))
+						return ERR_USERNOTINCHANNEL;
+					if (solveOperatorMode(channel, clientIt->second, addMode))
+					{
+						if (changeFlag)
+						{
+							modeChange += addMode ? '+' : '-';
+							changeFlag = false;
+						}
+						modeChange += *it;
+						paramChange += ' ' + *paramIt;
+					}
+					++paramIt;
+					break;
+				case 'l':
+					if (addMode && (params.size() == 0 || paramIt == params.end()))
+						return ERR_NEEDMOREPARAMS;
+					else if (addMode)
+					{
+						iss.clear();
+						iss.str(*paramIt);
+						iss >> limit;
+						if (!iss.eof() || paramIt->at(0) == '-' || limit == 0)
+							return ERR_UNKNOWNERROR;
+					}
+					if (solveLimitMode(channel, *it, limit, addMode))
+					{
+						if (changeFlag)
+						{
+							modeChange += addMode ? '+' : '-';
+							changeFlag = false;
+						}
+						modeChange += *it;
+						if (addMode)
+							paramChange += ' ' + *paramIt;
+					}
+					if (addMode)
 						++paramIt;
-						break;
-					default:
-						return ERR_UNKNOWNMODE + " " + *it;
+					break;
+				default:
+					return ERR_UNKNOWNMODE + " " + *it;
 				}
 			}
 			else
@@ -165,5 +233,6 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 	}
 	else
 		return ERR_CHANOPRIVSNEEDED;
+	modeChange += paramChange;
 	return RPL_SUCCESS;
 }

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -94,6 +94,16 @@ std::map<int, Client>::iterator findClientByNick(std::map<int, Client> &clients,
 	return it;
 }
 
+void appendModeChange(std::string &modeChange, char mode, bool addMode, bool &changeFlag)
+{
+	if (changeFlag)
+	{
+		modeChange += addMode ? '+' : '-';
+		changeFlag = false;
+	}
+	modeChange += mode;
+}
+
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange)
 {
 	bool addMode;
@@ -125,7 +135,6 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 			{
 				if (!addMode)
 					changeFlag = true;
-				// modeChange += '+';
 				addMode = true;
 				continue;
 			}
@@ -133,7 +142,6 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 			{
 				if (addMode)
 					changeFlag = true;
-				// modeChange += '-';
 				addMode = false;
 				continue;
 			}
@@ -143,37 +151,18 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 				{
 				case 'i':
 					if (solveInviteMode(channel, *it, addMode))
-					{
-						if (changeFlag)
-						{
-							modeChange += addMode ? '+' : '-';
-							changeFlag = false;
-						}
-						modeChange += *it;
-					}
+						appendModeChange(modeChange, *it, addMode, changeFlag);
 					break;
 				case 't':
 					if (solveTopicMode(channel, *it, addMode))
-					{
-						if (changeFlag)
-						{
-							modeChange += addMode ? '+' : '-';
-							changeFlag = false;
-						}
-						modeChange += *it;
-					}
+						appendModeChange(modeChange, *it, addMode, changeFlag);
 					break;
 				case 'k':
 					if (params.size() == 0 || paramIt == params.end())
 						return ERR_NEEDMOREPARAMS;
 					if (solveKeyMode(channel, *it, *paramIt, addMode))
 					{
-						if (changeFlag)
-						{
-							modeChange += addMode ? '+' : '-';
-							changeFlag = false;
-						}
-						modeChange += *it;
+						appendModeChange(modeChange, *it, addMode, changeFlag);
 						paramChange += ' ' + *paramIt;
 					}
 					++paramIt;
@@ -188,12 +177,7 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 						return ERR_USERNOTINCHANNEL;
 					if (solveOperatorMode(channel, clientIt->second, addMode))
 					{
-						if (changeFlag)
-						{
-							modeChange += addMode ? '+' : '-';
-							changeFlag = false;
-						}
-						modeChange += *it;
+						appendModeChange(modeChange, *it, addMode, changeFlag);
 						paramChange += ' ' + *paramIt;
 					}
 					++paramIt;
@@ -211,12 +195,7 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 					}
 					if (solveLimitMode(channel, *it, limit, addMode))
 					{
-						if (changeFlag)
-						{
-							modeChange += addMode ? '+' : '-';
-							changeFlag = false;
-						}
-						modeChange += *it;
+						appendModeChange(modeChange, *it, addMode, changeFlag);
 						if (addMode)
 							paramChange += ' ' + *paramIt;
 					}

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -27,6 +27,11 @@ void	addOperator(Channel &channel, Client client)
 	channel.addOperator(client.getFd());
 }
 
+void	removeOperator(Channel &channel, Client client)
+{
+	channel.removeOperator(client.getFd());
+}
+
 void	addUserLimit(Channel &channel, unsigned int limit)
 {
 	channel.setUserLimit(limit);
@@ -77,7 +82,8 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 				{
 					if (paramIt->size() == 0 || paramIt == params.end())
 						return ERR_NEEDMOREPARAMS;
-					switch (*next) {
+					switch (*next)
+					{
 						case 'k':
 							addKey(channel, *paramIt);
 							++paramIt;
@@ -108,9 +114,26 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 					channel.addMode(*next);
 				}
 				else
-				{
 					channel.addMode(*next);
-				}	
+			}
+			else if (*it == '-' && isValidMode(*next))
+			{
+				if (needParam(*it, *next))
+				{
+					if (paramIt->size() == 0 || paramIt == params.end())
+						return ERR_NEEDMOREPARAMS;
+					
+					clientIt = findClientByNick(clients, *paramIt);
+				
+					if (clientIt == clients.end())
+						return ERR_NOSUCHNICK;
+					if (!channel.isMember(clientIt->second.getFd()))
+						return ERR_USERNOTINCHANNEL;
+					removeOperator(channel, clientIt->second);
+					++paramIt;
+				}
+				else
+					channel.removeMode(*next);
 			}
 			else
 				return ERR_UNKNOWNMODE;

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -1,0 +1,10 @@
+#include "../../includes/utils/Utils.hpp"
+#include <vector>
+
+std::string	manageChannelMode(const Channel &channel, const std::string modes, const std::vector<std::string> params)
+{
+	(void)channel;
+	if (modes.empty() && params.size() == 0)
+		return RPL_CHANNELMODEIS;
+	return RPL_SUCCESS;
+}

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -1,4 +1,5 @@
 #include "../../includes/utils/Utils.hpp"
+#include <sstream>
 #include <vector>
 
 bool	needParam(char op, char mode)
@@ -28,17 +29,17 @@ void	addOperator(Channel &channel, std::string key)
 	(void)key;
 }
 
-void	addUserLimit(Channel &channel, std::string limit)
+void	addUserLimit(Channel &channel, unsigned int limit)
 {
-	(void)channel;
-	(void)limit;
-	
+	channel.setUserLimit(limit);
 }
 
 std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isOperator)
 {
 	std::vector<std::string>::iterator paramIt;
 	std::string	validModes = "+-itkol";
+	unsigned int	limit;
+	std::stringstream iss;
 
 	paramIt = params.begin();
 	if (modes.empty() && params.size() == 0)
@@ -73,12 +74,12 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 							break;
 						case 'l':
 
-							// unsigned int	limit;
-
-
-
-
-							addUserLimit(channel, *paramIt);
+							iss.clear();
+							iss.str(*paramIt);
+							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
+								addUserLimit(channel, limit);
+							else
+								return ERR_UNKNOWNMODE;
 							break;
 						default:
 							return ERR_UNKNOWNMODE;

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -86,6 +86,7 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 					{
 						case 'k':
 							addKey(channel, *paramIt);
+							channel.addMode(*next);
 							++paramIt;
 							break;
 						case 'o':
@@ -103,6 +104,7 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
 							{
 								addUserLimit(channel, limit);
+								channel.addMode(*next);
 								++paramIt;
 							}
 							else
@@ -111,7 +113,6 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 						default:
 							return ERR_UNKNOWNMODE;
 					}
-					channel.addMode(*next);
 				}
 				else
 					channel.addMode(*next);

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -106,24 +106,20 @@ void appendModeChange(std::string &modeChange, char mode, bool addMode, bool &ch
 
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange)
 {
-	bool addMode;
-	unsigned int limit;
-	std::string validModes;
-	std::stringstream iss;
-	std::map<int, Client>::iterator clientIt;
-	std::vector<std::string>::iterator paramIt;
-	std::string paramChange;
+	bool								addMode;
+	bool								changeFlag;
+	unsigned int						limit;
+	std::string							paramChange;
+	std::stringstream					iss;
+	std::map<int, Client>::iterator		clientIt;
+	std::vector<std::string>::iterator	paramIt;
 
 	limit = 0;
 	paramIt = params.begin();
-	validModes = "itkol";
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
 	if (!isMember)
 		return ERR_NOTONCHANNEL;
-
-	bool changeFlag;
-
 	if (isOperator)
 	{
 		if (modes.at(0) != '+' && modes.at(0) != '-')
@@ -145,7 +141,7 @@ std::string manageChannelMode(Channel &channel, std::string modes, std::vector<s
 				addMode = false;
 				continue;
 			}
-			if (validModes.find_first_of(*it) != std::string::npos)
+			if (std::string("itkol").find_first_of(*it) != std::string::npos)
 			{
 				switch (*it)
 				{

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -1,10 +1,108 @@
 #include "../../includes/utils/Utils.hpp"
 #include <vector>
 
-std::string	manageChannelMode(const Channel &channel, const std::string modes, const std::vector<std::string> params)
+bool	needParam(char op, char mode)
+{
+	if (op == '+' && (mode == 'k' || mode == 'o' || mode == 'l'))
+		return true;
+	if (op == '-' && mode == 'o')
+		return true;
+	return false;
+}
+
+bool	isValidMode(char mode)
+{
+	if (mode != '+' && mode != '-')
+		return true;
+	return false;
+}
+
+void	addKey(Channel &channel, std::string key)
+{
+	channel.setKey(key);
+}
+
+void	addOperator(Channel &channel, std::string key)
 {
 	(void)channel;
+	(void)key;
+}
+
+void	addUserLimit(Channel &channel, std::string limit)
+{
+	(void)channel;
+	(void)limit;
+	
+}
+
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isOperator)
+{
+	std::vector<std::string>::iterator paramIt;
+	std::string	validModes = "+-itkol";
+
+	paramIt = params.begin();
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
+	if (isOperator)
+	{
+		if (modes.find_first_not_of(validModes) != std::string::npos)
+			return ERR_UNKNOWNMODE;
+		if (modes.at(0) != '+' && modes.at(0) != '-')
+			return ERR_NEEDMOREPARAMS;
+		for (std::string::iterator it = modes.begin(); it != modes.end(); ++it)
+		{
+			std::string::iterator next = it;
+
+			++next;
+			if (next == modes.end())
+				continue;
+			
+			if (*it == '+' && isValidMode(*next))
+			{
+				if (needParam(*it, *next))
+				{
+					if (paramIt->size() == 0 || paramIt == params.end())
+						return ERR_NEEDMOREPARAMS;
+					switch (*next) {
+						case 'k':
+							addKey(channel, *paramIt);
+							++paramIt;
+							break;
+						case 'o':
+							addOperator(channel, *paramIt);
+							break;
+						case 'l':
+
+							// unsigned int	limit;
+
+
+
+
+							addUserLimit(channel, *paramIt);
+							break;
+						default:
+							return ERR_UNKNOWNMODE;
+					
+					}
+					channel.addMode(*next);
+				}
+				else
+				{
+					channel.addMode(*next);
+				}	
+			}
+			else
+				return ERR_UNKNOWNMODE;
+		
+
+
+		}
+
+	}
+	else
+		return ERR_CHANOPRIVSNEEDED;
+	
+	
+
 	return RPL_SUCCESS;
 }

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -1,6 +1,5 @@
 #include "../../includes/utils/Utils.hpp"
 #include <sstream>
-#include <vector>
 
 bool	needParam(char op, char mode)
 {
@@ -23,10 +22,9 @@ void	addKey(Channel &channel, std::string key)
 	channel.setKey(key);
 }
 
-void	addOperator(Channel &channel, std::string key)
+void	addOperator(Channel &channel, Client client)
 {
-	(void)channel;
-	(void)key;
+	channel.addOperator(client.getFd());
 }
 
 void	addUserLimit(Channel &channel, unsigned int limit)
@@ -34,18 +32,33 @@ void	addUserLimit(Channel &channel, unsigned int limit)
 	channel.setUserLimit(limit);
 }
 
-std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, bool isMember, bool isOperator)
+std::map<int, Client>::iterator	findClientByNick(std::map<int, Client> &clients, std::string &nick)
 {
-	std::vector<std::string>::iterator paramIt;
-	std::string	validModes = "+-itkol";
-	unsigned int	limit;
-	std::stringstream iss;
+	std::map<int, Client>::iterator it;
+
+	for (it = clients.begin(); it != clients.end(); ++it)
+	{
+		if (it->second.getNickname().compare(nick) == 0)
+			break;
+	}
+	return it;
+}
+
+std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator)
+{
+	unsigned int						limit;
+	std::string							validModes;
+	std::stringstream					iss;
+	std::map<int, Client>::iterator		clientIt;
+	std::vector<std::string>::iterator	paramIt;
 
 	paramIt = params.begin();
+	validModes = "+-itkol";
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
 	if (!isMember)
 		return ERR_NOTONCHANNEL;
+
 	if (isOperator)
 	{
 		if (modes.find_first_not_of(validModes) != std::string::npos)
@@ -55,11 +68,9 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 		for (std::string::iterator it = modes.begin(); it != modes.end(); ++it)
 		{
 			std::string::iterator next = it;
-
 			++next;
 			if (next == modes.end())
 				continue;
-			
 			if (*it == '+' && isValidMode(*next))
 			{
 				if (needParam(*it, *next))
@@ -72,20 +83,27 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 							++paramIt;
 							break;
 						case 'o':
-							addOperator(channel, *paramIt);
+							clientIt = findClientByNick(clients, *paramIt);
+							if (clientIt == clients.end())
+								return ERR_NOSUCHNICK;
+							if (!channel.isMember(clientIt->second.getFd()))
+								return ERR_USERNOTINCHANNEL;
+							addOperator(channel, clientIt->second);
+							++paramIt;
 							break;
 						case 'l':
-
 							iss.clear();
 							iss.str(*paramIt);
 							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
+							{
 								addUserLimit(channel, limit);
+								++paramIt;
+							}
 							else
 								return ERR_UNKNOWNMODE;
 							break;
 						default:
 							return ERR_UNKNOWNMODE;
-					
 					}
 					channel.addMode(*next);
 				}
@@ -96,16 +114,9 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 			}
 			else
 				return ERR_UNKNOWNMODE;
-		
-
-
 		}
-
 	}
 	else
 		return ERR_CHANOPRIVSNEEDED;
-	
-	
-
 	return RPL_SUCCESS;
 }

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -1,11 +1,10 @@
 #include "../../includes/utils/Utils.hpp"
+#include <iostream>
 #include <sstream>
 
-bool	needParam(char op, char mode)
+bool	needParam(char mode, bool isAddMode)
 {
-	if (op == '+' && (mode == 'k' || mode == 'o' || mode == 'l'))
-		return true;
-	if (op == '-' && mode == 'o')
+	if ((isAddMode && (mode == 'k' || mode == 'l')) || mode == 'o')
 		return true;
 	return false;
 }
@@ -17,14 +16,52 @@ bool	isValidMode(char mode)
 	return false;
 }
 
-void	addKey(Channel &channel, std::string key)
+void	solveInviteMode(Channel &channel, char mode, bool isAddMode)
 {
-	channel.setKey(key);
+	if (isAddMode)
+	{
+		channel.setInviteOnly(true);
+		channel.addMode(mode);
+	}
+	else 
+	{
+		channel.setInviteOnly(false);
+		channel.removeMode(mode);
+	}
 }
 
-void	addOperator(Channel &channel, Client client)
+void	solveTopicMode(Channel &channel, char mode, bool isAddMode)
 {
-	channel.addOperator(client.getFd());
+	if (isAddMode)
+	{
+		channel.setTopicProtected(true);
+		channel.addMode(mode);
+	}
+	else
+	{
+		channel.setTopicProtected(false);
+		channel.removeMode(mode);
+	}
+}
+
+void	solveKeyMode(Channel &channel, char mode, std::string key, bool isAddMode)
+{
+	if (isAddMode)
+	{
+		channel.setKey(key);
+		channel.addMode(mode);
+	}
+	else 
+	{
+		channel.setKey("");
+		channel.removeMode(mode);
+	}
+	
+}
+
+void	solveOperatorMode(Channel &channel, Client client, bool isAddMode)
+{
+	isAddMode ? channel.addOperator(client.getFd()) : channel.removeOperator(client.getFd());
 }
 
 void	removeOperator(Channel &channel, Client client)
@@ -32,9 +69,18 @@ void	removeOperator(Channel &channel, Client client)
 	channel.removeOperator(client.getFd());
 }
 
-void	addUserLimit(Channel &channel, unsigned int limit)
+void	solveLimitMode(Channel &channel, char mode, unsigned int limit, bool isAddMode)
 {
-	channel.setUserLimit(limit);
+	if (isAddMode)
+	{
+		channel.setUserLimit(limit);
+		channel.addMode(mode);
+	}
+	else
+	{
+		channel.setUserLimit(0);
+		channel.removeMode(mode);
+	}
 }
 
 std::map<int, Client>::iterator	findClientByNick(std::map<int, Client> &clients, std::string &nick)
@@ -57,8 +103,11 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 	std::map<int, Client>::iterator		clientIt;
 	std::vector<std::string>::iterator	paramIt;
 
+	bool								addMode;
+
 	paramIt = params.begin();
-	validModes = "+-itkol";
+	validModes = "itkol";
+	addMode = false;
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
 	if (!isMember)
@@ -66,18 +115,98 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 
 	if (isOperator)
 	{
-		if (modes.find_first_not_of(validModes) != std::string::npos)
-			return ERR_UNKNOWNMODE;
+		// if (modes.find_first_not_of(validModes) != std::string::npos)
+		// 	return ERR_UNKNOWNMODE;
 		if (modes.at(0) != '+' && modes.at(0) != '-')
-			return ERR_NEEDMOREPARAMS;
+			return ERR_UNKNOWNMODE + " " + modes.at(0);
 		for (std::string::iterator it = modes.begin(); it != modes.end(); ++it)
 		{
-			std::string::iterator next = it;
-			++next;
-			if (next == modes.end())
+			// std::string::iterator next = it;
+			// ++next;
+
+			// if (next == modes.end())
+			// 	continue;
+
+			if (*it == '+')
+			{
+				addMode = true;
 				continue;
+			}
+			if (*it == '-')
+			{
+				addMode = false;
+				continue;
+			}
+			
+			if (validModes.find_first_of(*it) != std::string::npos)
+			{
+				// if (needParam(*it, addMode))
+				// {
+					
+					// if (params.size() == 0 || paramIt == params.end())
+					// 	return ERR_NEEDMOREPARAMS;
+					
+
+					switch (*it)
+					{
+						case 'i':
+							solveInviteMode(channel, *it, addMode);
+							break;
+						case 't':
+
+
+							solveTopicMode(channel, *it, addMode);
+							break;
+						case 'k':
+							if (params.size() == 0 || paramIt == params.end())
+								return ERR_NEEDMOREPARAMS;
+							solveKeyMode(channel, *it, *paramIt, addMode);
+							++paramIt;
+							break;
+						case 'o':
+							if (params.size() == 0 || paramIt == params.end())
+								return ERR_NEEDMOREPARAMS;
+							clientIt = findClientByNick(clients, *paramIt);
+							if (clientIt == clients.end())
+								return ERR_NOSUCHNICK;
+							if (!channel.isMember(clientIt->second.getFd()))
+								return ERR_USERNOTINCHANNEL;
+							solveOperatorMode(channel, clientIt->second, addMode);
+							++paramIt;
+							break;
+						case 'l':
+							if (addMode && (params.size() == 0 || paramIt == params.end()))
+								return ERR_NEEDMOREPARAMS;
+							iss.clear();
+							iss.str(*paramIt);
+							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
+							{
+								solveLimitMode(channel, *it, limit, addMode);
+								++paramIt;
+							}
+							else
+								return ERR_UNKNOWNERROR;
+							break;
+						default:
+							return ERR_UNKNOWNMODE + " " + *it;
+					}
+				// }
+
+			}
+			else
+				return ERR_UNKNOWNMODE + " " + *it;
+			
+			
+
+
+
+			/*
 			if (*it == '+' && isValidMode(*next))
 			{
+
+				if (validModes.find_first_of(*next) == std::string::npos)
+					return ERR_UNKNOWNMODE + " " + *next;
+
 				if (needParam(*it, *next))
 				{
 					if (paramIt->size() == 0 || paramIt == params.end())
@@ -108,10 +237,10 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 								++paramIt;
 							}
 							else
-								return ERR_UNKNOWNMODE;
+								return ERR_UNKNOWNERROR;
 							break;
 						default:
-							return ERR_UNKNOWNMODE;
+							return ERR_UNKNOWNMODE + " " + *next;
 					}
 				}
 				else
@@ -119,6 +248,10 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 			}
 			else if (*it == '-' && isValidMode(*next))
 			{
+
+				if (validModes.find_first_of(*next) == std::string::npos)
+					return ERR_UNKNOWNMODE + " " + *next;
+
 				if (needParam(*it, *next))
 				{
 					if (paramIt->size() == 0 || paramIt == params.end())
@@ -137,7 +270,8 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 					channel.removeMode(*next);
 			}
 			else
-				return ERR_UNKNOWNMODE;
+				return ERR_UNKNOWNMODE + " " + *it;
+			*/
 		}
 	}
 	else

--- a/src/commands/MODE.cpp
+++ b/src/commands/MODE.cpp
@@ -2,20 +2,6 @@
 #include <iostream>
 #include <sstream>
 
-bool	needParam(char mode, bool isAddMode)
-{
-	if ((isAddMode && (mode == 'k' || mode == 'l')) || mode == 'o')
-		return true;
-	return false;
-}
-
-bool	isValidMode(char mode)
-{
-	if (mode != '+' && mode != '-')
-		return true;
-	return false;
-}
-
 void	solveInviteMode(Channel &channel, char mode, bool isAddMode)
 {
 	if (isAddMode)
@@ -56,7 +42,6 @@ void	solveKeyMode(Channel &channel, char mode, std::string key, bool isAddMode)
 		channel.setKey("");
 		channel.removeMode(mode);
 	}
-	
 }
 
 void	solveOperatorMode(Channel &channel, Client client, bool isAddMode)
@@ -97,17 +82,17 @@ std::map<int, Client>::iterator	findClientByNick(std::map<int, Client> &clients,
 
 std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator)
 {
+	bool								addMode;
 	unsigned int						limit;
 	std::string							validModes;
 	std::stringstream					iss;
 	std::map<int, Client>::iterator		clientIt;
 	std::vector<std::string>::iterator	paramIt;
 
-	bool								addMode;
-
+	addMode = false;
+	limit = 0;
 	paramIt = params.begin();
 	validModes = "itkol";
-	addMode = false;
 	if (modes.empty() && params.size() == 0)
 		return RPL_CHANNELMODEIS;
 	if (!isMember)
@@ -115,18 +100,10 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 
 	if (isOperator)
 	{
-		// if (modes.find_first_not_of(validModes) != std::string::npos)
-		// 	return ERR_UNKNOWNMODE;
 		if (modes.at(0) != '+' && modes.at(0) != '-')
 			return ERR_UNKNOWNMODE + " " + modes.at(0);
 		for (std::string::iterator it = modes.begin(); it != modes.end(); ++it)
 		{
-			// std::string::iterator next = it;
-			// ++next;
-
-			// if (next == modes.end())
-			// 	continue;
-
 			if (*it == '+')
 			{
 				addMode = true;
@@ -137,141 +114,53 @@ std::string	manageChannelMode(Channel &channel, std::string modes, std::vector<s
 				addMode = false;
 				continue;
 			}
-			
 			if (validModes.find_first_of(*it) != std::string::npos)
 			{
-				// if (needParam(*it, addMode))
-				// {
-					
-					// if (params.size() == 0 || paramIt == params.end())
-					// 	return ERR_NEEDMOREPARAMS;
-					
-
-					switch (*it)
-					{
-						case 'i':
-							solveInviteMode(channel, *it, addMode);
-							break;
-						case 't':
-
-
-							solveTopicMode(channel, *it, addMode);
-							break;
-						case 'k':
-							if (params.size() == 0 || paramIt == params.end())
-								return ERR_NEEDMOREPARAMS;
-							solveKeyMode(channel, *it, *paramIt, addMode);
-							++paramIt;
-							break;
-						case 'o':
-							if (params.size() == 0 || paramIt == params.end())
-								return ERR_NEEDMOREPARAMS;
-							clientIt = findClientByNick(clients, *paramIt);
-							if (clientIt == clients.end())
-								return ERR_NOSUCHNICK;
-							if (!channel.isMember(clientIt->second.getFd()))
-								return ERR_USERNOTINCHANNEL;
-							solveOperatorMode(channel, clientIt->second, addMode);
-							++paramIt;
-							break;
-						case 'l':
-							if (addMode && (params.size() == 0 || paramIt == params.end()))
-								return ERR_NEEDMOREPARAMS;
+				switch (*it)
+				{
+					case 'i':
+						solveInviteMode(channel, *it, addMode);
+						break;
+					case 't':
+						solveTopicMode(channel, *it, addMode);
+						break;
+					case 'k':
+						if (params.size() == 0 || paramIt == params.end())
+							return ERR_NEEDMOREPARAMS;
+						solveKeyMode(channel, *it, *paramIt, addMode);
+						++paramIt;
+						break;
+					case 'o':
+						if (params.size() == 0 || paramIt == params.end())
+							return ERR_NEEDMOREPARAMS;
+						clientIt = findClientByNick(clients, *paramIt);
+						if (clientIt == clients.end())
+							return ERR_NOSUCHNICK;
+						if (!channel.isMember(clientIt->second.getFd()))
+							return ERR_USERNOTINCHANNEL;
+						solveOperatorMode(channel, clientIt->second, addMode);
+						++paramIt;
+						break;
+					case 'l':
+						if (addMode && (params.size() == 0 || paramIt == params.end()))
+							return ERR_NEEDMOREPARAMS;
+						else if (addMode)
+						{
 							iss.clear();
 							iss.str(*paramIt);
-							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
-							{
-								solveLimitMode(channel, *it, limit, addMode);
-								++paramIt;
-							}
-							else
+							iss >> limit;
+							if (!iss.eof() || paramIt->at(0) == '-')
 								return ERR_UNKNOWNERROR;
-							break;
-						default:
-							return ERR_UNKNOWNMODE + " " + *it;
-					}
-				// }
-
+						}
+						solveLimitMode(channel, *it, limit, addMode);
+						++paramIt;
+						break;
+					default:
+						return ERR_UNKNOWNMODE + " " + *it;
+				}
 			}
 			else
 				return ERR_UNKNOWNMODE + " " + *it;
-			
-			
-
-
-
-			/*
-			if (*it == '+' && isValidMode(*next))
-			{
-
-				if (validModes.find_first_of(*next) == std::string::npos)
-					return ERR_UNKNOWNMODE + " " + *next;
-
-				if (needParam(*it, *next))
-				{
-					if (paramIt->size() == 0 || paramIt == params.end())
-						return ERR_NEEDMOREPARAMS;
-					switch (*next)
-					{
-						case 'k':
-							addKey(channel, *paramIt);
-							channel.addMode(*next);
-							++paramIt;
-							break;
-						case 'o':
-							clientIt = findClientByNick(clients, *paramIt);
-							if (clientIt == clients.end())
-								return ERR_NOSUCHNICK;
-							if (!channel.isMember(clientIt->second.getFd()))
-								return ERR_USERNOTINCHANNEL;
-							addOperator(channel, clientIt->second);
-							++paramIt;
-							break;
-						case 'l':
-							iss.clear();
-							iss.str(*paramIt);
-							if (iss >> limit && iss.eof() && paramIt->at(0) != '-')
-							{
-								addUserLimit(channel, limit);
-								channel.addMode(*next);
-								++paramIt;
-							}
-							else
-								return ERR_UNKNOWNERROR;
-							break;
-						default:
-							return ERR_UNKNOWNMODE + " " + *next;
-					}
-				}
-				else
-					channel.addMode(*next);
-			}
-			else if (*it == '-' && isValidMode(*next))
-			{
-
-				if (validModes.find_first_of(*next) == std::string::npos)
-					return ERR_UNKNOWNMODE + " " + *next;
-
-				if (needParam(*it, *next))
-				{
-					if (paramIt->size() == 0 || paramIt == params.end())
-						return ERR_NEEDMOREPARAMS;
-					
-					clientIt = findClientByNick(clients, *paramIt);
-				
-					if (clientIt == clients.end())
-						return ERR_NOSUCHNICK;
-					if (!channel.isMember(clientIt->second.getFd()))
-						return ERR_USERNOTINCHANNEL;
-					removeOperator(channel, clientIt->second);
-					++paramIt;
-				}
-				else
-					channel.removeMode(*next);
-			}
-			else
-				return ERR_UNKNOWNMODE + " " + *it;
-			*/
 		}
 	}
 	else

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -1,6 +1,5 @@
 #include "../../includes/server/Channel.hpp"
 #include <algorithm>
-#include <iostream>
 
 Channel::Channel() : _name(), _clients(), _operators() {}
 
@@ -30,6 +29,11 @@ void Channel::removeClient(int clientFd)
 	_operators.erase(clientFd);
 }
 
+void Channel::removeOperator(int clientFd)
+{
+	_operators.erase(clientFd);
+}
+
 void Channel::addOperator(int clientFd)
 {
 	if (_clients.count(clientFd))
@@ -45,8 +49,6 @@ const std::string &Channel::getName() const { return _name; }
 const std::set<int> &Channel::getClients() const { return _clients; }
 
 const std::set<int> &Channel::getOperators() const { return _operators; };
-
-// std::set<int> &Channel::getOperators() { return _operators; };
 
 const std::string &Channel::getTopic() const { return _topic; }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -74,8 +74,8 @@ bool Channel::addMode(char mode)
 			_modes.push_back(mode);
 			break;
 		case 'k':
-			if (_modes.size() >= 2)
-				_modes.insert(0, 1, mode);
+			if (_modes.size() >= 1 && _modes.at(_modes.size() - 1) == 'l')
+				_modes.insert(_modes.size() - 1, 1, mode);
 			else
 				_modes.push_back(mode);
 			break;

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -58,6 +58,10 @@ const std::string &Channel::getKey() const { return _key; }
 
 const unsigned int &Channel::getUserLimit() const { return _userLimit; }
 
+const bool Channel::isInviteOnly() const { return _inviteOnly; }
+
+const bool Channel::isTopicProtected() const { return _topicProtected; }
+
 void Channel::setTopic(std::string topic) { _topic = topic; }
 
 void Channel::setModes(std::string &modes) { _modes = modes; }
@@ -71,6 +75,10 @@ void Channel::addMode(char mode)
 void Channel::setKey(std::string key) { _key = key; }
 
 void Channel::setUserLimit(unsigned int limit) { _userLimit = limit; }
+
+void Channel::setInviteOnly(bool mode) { _inviteOnly = mode; }
+
+void Channel::setTopicProtected(bool mode) { _topicProtected = mode; }
 
 void Channel::removeMode(char mode) { _modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end()); }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -1,9 +1,10 @@
 #include "../../includes/server/Channel.hpp"
 #include <algorithm>
+#include <sstream>
 
-Channel::Channel() : _name(), _clients(), _operators() {}
+Channel::Channel() : _name(), _clients(), _operators(), _userLimit(0) {}
 
-Channel::Channel(const std::string &name) : _name(name), _clients(), _operators() {}
+Channel::Channel(const std::string &name) : _name(name), _clients(), _operators(), _userLimit(0) {}
 
 Channel &Channel::operator=(const Channel &other)
 {
@@ -69,7 +70,30 @@ void Channel::setModes(std::string &modes) { _modes = modes; }
 void Channel::addMode(char mode)
 {
 	if (_modes.find(mode) == std::string::npos)
-		_modes += mode;
+	{
+		switch (mode)
+		{
+			case 'l':
+				_modes.push_back(mode);
+				break;
+			case 'k':
+				if (_modes.size() >= 2)
+					_modes.insert(_modes.size() - 2, 1, mode); 
+				else
+					_modes.push_back(mode);
+			break;
+			default:
+				_modes.insert(0, 1, mode);
+		}
+	}
+}
+
+const std::string Channel::getUserLimitStr() const
+{
+	std::ostringstream oss;
+
+	oss << _userLimit;
+	return oss.str();
 }
 
 void Channel::setKey(std::string key) { _key = key; }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -46,6 +46,8 @@ const std::set<int> &Channel::getClients() const { return _clients; }
 
 const std::set<int> &Channel::getOperators() const { return _operators; };
 
+// std::set<int> &Channel::getOperators() { return _operators; };
+
 const std::string &Channel::getTopic() const { return _topic; }
 
 const std::string &Channel::getModes() const { return _modes; }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -30,10 +30,7 @@ void Channel::removeClient(int clientFd)
 	_operators.erase(clientFd);
 }
 
-void Channel::removeOperator(int clientFd)
-{
-	_operators.erase(clientFd);
-}
+void Channel::removeOperator(int clientFd) { _operators.erase(clientFd); }
 
 void Channel::addOperator(int clientFd)
 {
@@ -67,25 +64,27 @@ void Channel::setTopic(std::string topic) { _topic = topic; }
 
 void Channel::setModes(std::string &modes) { _modes = modes; }
 
-void Channel::addMode(char mode)
+bool Channel::addMode(char mode)
 {
 	if (_modes.find(mode) == std::string::npos)
 	{
 		switch (mode)
 		{
-			case 'l':
-				_modes.push_back(mode);
-				break;
-			case 'k':
-				if (_modes.size() >= 2)
-					_modes.insert(_modes.size() - 2, 1, mode); 
-				else
-					_modes.push_back(mode);
+		case 'l':
+			_modes.push_back(mode);
 			break;
-			default:
+		case 'k':
+			if (_modes.size() >= 2)
 				_modes.insert(0, 1, mode);
+			else
+				_modes.push_back(mode);
+			break;
+		default:
+			_modes.insert(0, 1, mode);
 		}
+		return true;
 	}
+	return false;
 }
 
 const std::string Channel::getUserLimitStr() const
@@ -104,7 +103,15 @@ void Channel::setInviteOnly(bool mode) { _inviteOnly = mode; }
 
 void Channel::setTopicProtected(bool mode) { _topicProtected = mode; }
 
-void Channel::removeMode(char mode) { _modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end()); }
+bool Channel::removeMode(char mode)
+{
+	if (_modes.find_first_of(mode) != std::string::npos)
+	{
+		_modes.erase(std::remove(_modes.begin(), _modes.end(), mode), _modes.end());
+		return true;
+	}
+	return false;
+}
 
 void Channel::removeInvite(int clientFd) { _inviteList.erase(clientFd); }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -58,9 +58,9 @@ const std::string &Channel::getKey() const { return _key; }
 
 const unsigned int &Channel::getUserLimit() const { return _userLimit; }
 
-const bool Channel::isInviteOnly() const { return _inviteOnly; }
+const bool &Channel::isInviteOnly() const { return _inviteOnly; }
 
-const bool Channel::isTopicProtected() const { return _topicProtected; }
+const bool &Channel::isTopicProtected() const { return _topicProtected; }
 
 void Channel::setTopic(std::string topic) { _topic = topic; }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -403,7 +403,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		modes = tokens[2];
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
-	res = manageChannelMode(chanIt->second, modes, params, chanIt->second.isOperator(client.getFd()));
+	res = manageChannelMode(chanIt->second, modes, params, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
 
 	
 	std::cout << "key -> " << chanIt->second.getKey() << std::endl;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -412,14 +412,19 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
 
-	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
-
-	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it)
-		std::cout << "operator -> " << *it << std::endl;
+	res = manageChannelMode(
+			chanIt->second, 
+			modes, 
+			params, 
+			_clients, 
+			chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
 
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 	{
-		sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " + showChannelModes(chanIt->second));
+		sendMessage(
+				client.getFd(),
+				":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName()
+				+ " " + showChannelModes(chanIt->second));
 		return;
 	}
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
@@ -432,7 +437,11 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		sendError(client, "MODE", res);
 		return;
 	}
-	broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
+	if (!modeChange.empty())
+		broadcastToChannel(
+				chanIt->second.getName(), 
+				":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " 
+				+ chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -216,12 +216,7 @@ void Server::sendError(Client &client, const std::string &command, const std::st
 {
 	std::map<std::string, std::string>::iterator it = _errorDescriptions.find(errorCode);
 	if (it != _errorDescriptions.end())
-		sendMessage(client.getFd(),
-			  ":" + _serverName + " "
-			  + (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode)
-			  + " " + command
-			  + " " + extra + (extra.empty() ? "" : " ")
-			  + it->second);
+		sendMessage(client.getFd(), ":" + _serverName + " " + (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode) + " " + command + " " + extra + (extra.empty() ? "" : " ") + it->second);
 }
 
 void Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
@@ -394,8 +389,8 @@ void Server::handlePing(Client &client, const std::string &rawMsg, const std::ve
 
 void Server::handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::string	res;
-	std::string	modes;
+	std::string res;
+	std::string modes;
 	std::vector<std::string> params;
 	std::map<std::string, Channel>::iterator chanIt;
 
@@ -418,21 +413,25 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 
 	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
 
-	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it) std::cout << "operator -> " << *it << std::endl;
-	
+	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it)
+		std::cout << "operator -> " << *it << std::endl;
+
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
-		sendMessage(client.getFd(), ":" + _serverName + " " 
-			+ RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
-			+ showChannelModes(chanIt->second));
+	{
+		sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " + showChannelModes(chanIt->second));
+		return;
+	}
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
+	{
 		sendError(client, "MODE", ERR_UNKNOWNMODE, res.substr(ERR_UNKNOWNMODE.size() + 1));
+		return;
+	}
 	else if (res.compare(RPL_SUCCESS) != 0)
+	{
 		sendError(client, "MODE", res);
-	broadcastToChannel(
-		chanIt->second.getName(),
-			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " "
-					+ showChannelModes(chanIt->second),
-		client.getFd());
+		return;
+	}
+	broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + showChannelModes(chanIt->second), client.getFd());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -212,11 +212,15 @@ void Server::broadcastToChannel(const std::string &channelName, const std::strin
 	}
 }
 
-void Server::sendError(Client &client, const std::string &command, const std::string &errorCode)
+void Server::sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra = "")
 {
 	std::map<std::string, std::string>::iterator it = _errorDescriptions.find(errorCode);
 	if (it != _errorDescriptions.end())
-		sendMessage(client.getFd(), (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode) + " " + command + " " + it->second);
+		sendMessage(client.getFd(), 
+			  (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode)
+			  + " " + command 
+			  + " " + extra + (extra.empty() ? "" : " ")
+			  + it->second);
 }
 
 void Server::handlePass(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
@@ -416,6 +420,8 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 			  + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
 			  + (chanIt->second.getModes().empty() ? "" : "+" + chanIt->second.getModes())
 			  + (chanIt->second.getKey().empty() ? "" : " secret " + chanIt->second.getKey()));
+	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
+		sendError(client, "MODE", ERR_UNKNOWNMODE, res.substr(ERR_UNKNOWNMODE.size() + 1));
 	else if (res.compare(RPL_SUCCESS) != 0)
 		sendError(client, "MODE", res);
 }
@@ -450,6 +456,8 @@ void Server::initErrorDescriptions()
 	_errorDescriptions[ERR_INVALIDMODE] = ":invalid mode (not 0)";
 	_errorDescriptions[ERR_INVALIDUNUSED] = ":invalid unused (not *)";
 	_errorDescriptions[ERR_INVALIDREALNAME] = ":invalid realname";
+	_errorDescriptions[ERR_UNKNOWNMODE] = ":is unknown mode char to me";
+	_errorDescriptions[ERR_NEEDMOREPARAMS] = ":not enough parameters";
 	_errorDescriptions[ERR_UNKNOWNERROR] = ":unknown error";
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -400,26 +400,21 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		sendError(client, "MODE", ERR_NOSUCHCHANNEL);
 		return;
 	}
-
 	if (tokens.size() >= 3)
 		modes = tokens[2];
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
+
 	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
-
-	
-	std::cout << "return -> " << res << std::endl;
-	std::cout << "key -> " << chanIt->second.getKey() << std::endl;
-	std::cout << "limit -> " << chanIt->second.getUserLimit() << std::endl;
-
 
 	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it) std::cout << "operator -> " << *it << std::endl;
 	
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 		sendMessage(client.getFd(), ":" + _serverName + " " 
-			  + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
-			  + (chanIt->second.getModes().empty() ? "" : "+" + chanIt->second.getModes())
-			  + (chanIt->second.getKey().empty() ? "" : " secret " + chanIt->second.getKey()));
+			+ RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
+			+ (chanIt->second.getModes().empty() ? "" : "+" + chanIt->second.getModes())
+			+ (chanIt->second.getKey().empty() ? "" : " " + chanIt->second.getKey())
+			+ (chanIt->second.getUserLimit() == 0 ? "" : " " + chanIt->second.getUserLimitStr()));
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
 		sendError(client, "MODE", ERR_UNKNOWNMODE, res.substr(ERR_UNKNOWNMODE.size() + 1));
 	else if (res.compare(RPL_SUCCESS) != 0)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -414,7 +414,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 		sendMessage(client.getFd(), ":" + _serverName + " " 
 			  + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
-			  + (chanIt->second.getModes().empty() ? "" : chanIt->second.getModes())
+			  + (chanIt->second.getModes().empty() ? "" : "+" + chanIt->second.getModes())
 			  + (chanIt->second.getKey().empty() ? "" : " secret " + chanIt->second.getKey()));
 	else if (res.compare(RPL_SUCCESS) != 0)
 		sendError(client, "MODE", res);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -393,6 +393,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	std::string modes;
 	std::vector<std::string> params;
 	std::map<std::string, Channel>::iterator chanIt;
+	std::string modeChange;
 
 	(void)rawMsg;
 	if (tokens.size() < 2)
@@ -411,7 +412,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
 
-	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
+	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
 
 	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it)
 		std::cout << "operator -> " << *it << std::endl;
@@ -431,7 +432,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		sendError(client, "MODE", res);
 		return;
 	}
-	broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + showChannelModes(chanIt->second), client.getFd());
+	broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -403,7 +403,12 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		modes = tokens[2];
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
-	res = manageChannelMode(chanIt->second, modes, params);
+	res = manageChannelMode(chanIt->second, modes, params, chanIt->second.isOperator(client.getFd()));
+
+	
+	std::cout << "key -> " << chanIt->second.getKey() << std::endl;
+
+
 
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 		sendMessage(client.getFd(), ":" + _serverName + " " 
@@ -440,6 +445,7 @@ void Server::initErrorDescriptions()
 	_errorDescriptions[ERR_INVALIDMODE] = ":invalid mode (not 0)";
 	_errorDescriptions[ERR_INVALIDUNUSED] = ":invalid unused (not *)";
 	_errorDescriptions[ERR_INVALIDREALNAME] = ":invalid realname";
+	_errorDescriptions[ERR_UNKNOWNERROR] = ":unknown error";
 }
 
 void Server::handleClientData(int clientFd)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -219,7 +219,7 @@ void Server::sendError(Client &client, const std::string &command, const std::st
 		sendMessage(client.getFd(),
 			  ":" + _serverName + " "
 			  + (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode)
-			  + " " + command 
+			  + " " + command
 			  + " " + extra + (extra.empty() ? "" : " ")
 			  + it->second);
 }
@@ -278,7 +278,6 @@ std::string Server::showClientsInChannel(Channel &channel)
 
 	for (std::set<int>::iterator it = channel.getClients().begin(); it != channel.getClients().end(); ++it)
 	{
-
 		std::set<int>::iterator next_it = it;
 		++next_it;
 		std::map<int, Client>::iterator client_it = _clients.find(*it);
@@ -293,6 +292,17 @@ std::string Server::showClientsInChannel(Channel &channel)
 			names += " ";
 	}
 	return names;
+}
+
+std::string Server::showChannelModes(Channel &channel)
+{
+	std::string message;
+
+	message += channel.getModes().empty() ? "" : "+" + channel.getModes();
+	message += channel.getKey().empty() ? "" : " " + channel.getKey();
+	message += channel.getUserLimit() == 0 ? "" : " " + channel.getUserLimitStr();
+
+	return message;
 }
 
 void Server::sendJoinMessage(Client &client, Channel &channel)
@@ -413,13 +423,16 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 		sendMessage(client.getFd(), ":" + _serverName + " " 
 			+ RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
-			+ (chanIt->second.getModes().empty() ? "" : "+" + chanIt->second.getModes())
-			+ (chanIt->second.getKey().empty() ? "" : " " + chanIt->second.getKey())
-			+ (chanIt->second.getUserLimit() == 0 ? "" : " " + chanIt->second.getUserLimitStr()));
+			+ showChannelModes(chanIt->second));
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
 		sendError(client, "MODE", ERR_UNKNOWNMODE, res.substr(ERR_UNKNOWNMODE.size() + 1));
 	else if (res.compare(RPL_SUCCESS) != 0)
 		sendError(client, "MODE", res);
+	broadcastToChannel(
+		chanIt->second.getName(),
+			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " "
+					+ showChannelModes(chanIt->second),
+		client.getFd());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -380,13 +380,38 @@ void Server::handlePing(Client &client, const std::string &rawMsg, const std::ve
 void Server::handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::string	res;
+	std::string	modes;
+	std::vector<std::string> params;
+	std::map<std::string, Channel>::iterator chanIt;
 
+
+	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
-		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PING " + MSG_NEEDMOREPARAMS);
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " MODE " + MSG_NEEDMOREPARAMS);
+		return;
+	}
+	
+	chanIt = _channels.find(tokens[1]);
+	if (chanIt == _channels.end())
+	{
+		sendError(client, "MODE", ERR_NOSUCHCHANNEL);
 		return;
 	}
 
+	if (tokens.size() >= 3)
+		modes = tokens[2];
+	if (tokens.size() >= 4)
+		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
+	res = manageChannelMode(chanIt->second, modes, params);
+
+	if (res.compare(RPL_CHANNELMODEIS) == 0)
+		sendMessage(client.getFd(), ":" + _serverName + " " 
+			  + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
+			  + (chanIt->second.getModes().empty() ? "" : chanIt->second.getModes())
+			  + (chanIt->second.getKey().empty() ? "" : " secret " + chanIt->second.getKey()));
+	else if (res.compare(RPL_SUCCESS) != 0)
+		sendError(client, "MODE", res);
 }
 
 void Server::initCommandMap()
@@ -397,6 +422,7 @@ void Server::initCommandMap()
 	_cmdMap["JOIN"] = &Server::handleJoin;
 	_cmdMap["CAP"] = &Server::handleCap;
 	_cmdMap["PING"] = &Server::handlePing;
+	_cmdMap["MODE"] = &Server::handleMode;
 }
 
 void Server::initErrorDescriptions()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -216,8 +216,9 @@ void Server::sendError(Client &client, const std::string &command, const std::st
 {
 	std::map<std::string, std::string>::iterator it = _errorDescriptions.find(errorCode);
 	if (it != _errorDescriptions.end())
-		sendMessage(client.getFd(), 
-			  (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode)
+		sendMessage(client.getFd(),
+			  ":" + _serverName + " "
+			  + (errorCode == "900" || errorCode == "901" || errorCode == "902" || errorCode == "903" ? ERR_NEEDMOREPARAMS : errorCode)
 			  + " " + command 
 			  + " " + extra + (extra.empty() ? "" : " ")
 			  + it->second);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -377,6 +377,18 @@ void Server::handlePing(Client &client, const std::string &rawMsg, const std::ve
 	}
 }
 
+void Server::handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	std::string	res;
+
+	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PING " + MSG_NEEDMOREPARAMS);
+		return;
+	}
+
+}
+
 void Server::initCommandMap()
 {
 	_cmdMap["PASS"] = &Server::handlePass;

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -384,14 +384,12 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	std::vector<std::string> params;
 	std::map<std::string, Channel>::iterator chanIt;
 
-
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " MODE " + MSG_NEEDMOREPARAMS);
 		return;
 	}
-	
 	chanIt = _channels.find(tokens[1]);
 	if (chanIt == _channels.end())
 	{
@@ -403,14 +401,16 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		modes = tokens[2];
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
-	res = manageChannelMode(chanIt->second, modes, params, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
+	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()));
 
 	
+	std::cout << "return -> " << res << std::endl;
 	std::cout << "key -> " << chanIt->second.getKey() << std::endl;
 	std::cout << "limit -> " << chanIt->second.getUserLimit() << std::endl;
 
 
-
+	for (std::set<int>::iterator it = chanIt->second.getOperators().begin(); it != chanIt->second.getOperators().end(); ++it) std::cout << "operator -> " << *it << std::endl;
+	
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 		sendMessage(client.getFd(), ":" + _serverName + " " 
 			  + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " 
@@ -439,7 +439,11 @@ void Server::initErrorDescriptions()
 	_errorDescriptions[ERR_NICKNAMEINUSE] = ":Nickname is already in use";
 	_errorDescriptions[ERR_NOTREGISTERED] = ":Not registered";
 	_errorDescriptions[ERR_NOSUCHCHANNEL] = ":No such channel";
+	_errorDescriptions[ERR_NOTONCHANNEL] = ":You're not on that channel";
+	_errorDescriptions[ERR_NOSUCHNICK] = ":No such nick/channel";
 	_errorDescriptions[ERR_CHANNELISFULL] = ":Channel is full";
+	_errorDescriptions[ERR_CHANOPRIVSNEEDED] = ":You're not channel operator";
+	_errorDescriptions[ERR_USERNOTINCHANNEL] = ":They aren't on that channel";
 	_errorDescriptions[ERR_INVITEONLYCHAN] = ":Client not invited";
 	_errorDescriptions[ERR_BADCHANNELKEY] = ":Wrong key";
 	_errorDescriptions[ERR_INVALIDUSERNAME] = ":invalid username";

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -407,6 +407,7 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 
 	
 	std::cout << "key -> " << chanIt->second.getKey() << std::endl;
+	std::cout << "limit -> " << chanIt->second.getUserLimit() << std::endl;
 
 
 


### PR DESCRIPTION
## Summary

Implements `MODE #channel [+|-flags] [params]` — channel mode management.

Implements all 5 required modes: `i`, `t`, `k`, `o`, `l`.

**Closes #41**

## Changes

- New `src/commands/MODE.cpp` — mode parsing, validation, application
- `src/server/Server.cpp` — `handleMode()`, `showChannelModes()`, error handling, mode broadcast
- `src/server/Channel.cpp` — invite-only/topic-protected flags, mode string ordering, `getUserLimitStr()`
- `includes/server/Channel.hpp` — new getters/setters for modes
- `includes/server/Server.hpp` — `handleMode`, `showChannelModes` declarations
- `includes/utils/Utils.hpp` — new error constants (`ERR_UNKNOWNERROR`, `ERR_KEYSET`, `ERR_UNKNOWNMODE`, etc.)
- `Makefile` — added `MODE.cpp`

## RFC 2811 Compliance Notes

- **`MODE #channel -k wrongkey`**: Key is removed regardless of the provided parameter value. This matches RFC 2811 and common implementations (InspIRCd, UnrealIRCd, ircd-hybrid).
- **`MODE #channel +l <non-numeric>`**: Invalid limit values (non-numeric, negative) return ERR_UNKNOWNERROR  instead of silently ignore it. I have decided for that in spite of it being against what's prescribed by RFC 2811. 

## Acceptance Criteria

- [ ] All 5 modes work: `i`, `t`, `k`, `o`, `l`
- [ ] Only operators can change modes (except query)
- [ ] Query returns current modes with `RPL_CHANNELMODEIS 324`
- [ ] Mode changes are broadcast to all channel members
- [ ] `+k` rejects with 467 if key already set
- [ ] `+l` validates positive integer
- [ ] `+o` validates target is channel member
- [ ] Unknown modes return `ERR_UNKNOWNMODE 472`
- [ ] Code compiles with `-Wall -Wextra -Werror`