### PR TITLE
fix: fix trailing colon parsing in message split (closes #54)

### DIFF
--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -59,7 +59,7 @@ const std::string MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 std::string authPass(Client &client, std::string password, std::string server_password);
 std::string setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
-std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
+std::string setClientUsername(std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);

--- a/src/commands/USER.cpp
+++ b/src/commands/USER.cpp
@@ -33,7 +33,7 @@ bool	parseRealName(std::string realname, Client &client)
 	return (true);
 }
 
-std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
+std::string	setClientUsername(std::vector<std::string> split_msg, Client &client)
 {
 	for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
 	{

--- a/src/commands/USER.cpp
+++ b/src/commands/USER.cpp
@@ -22,29 +22,19 @@ bool	parseUsername(std::string username, Client &client)
 	return (true);
 }
 
-bool	fetchRealName(std::string message, Client &client)
+bool	parseRealName(std::string realname, Client &client)
 {
-	size_t	colonPos;
-	size_t	found;
-	std::string	realName;
-
-	colonPos = message.find_first_of(':') + 1;
-	realName = message.substr(colonPos, message.length());
-	realName.erase(realName.length());
-	found = realName.find_first_of("\r\n\0");
-	if (found != std::string::npos)
+	if (realname.find_first_of("\r\n\0") != std::string::npos)
 	{
 		std::cout << "Invalid real name. Client FD: " << client.getFd() << std::endl;	
 		return (false);
 	}
-	client.setRealname(realName);
+	client.setRealname(realname);
 	return (true);
 }
 
 std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
 {
-	std::string realname;
-
 	for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
 	{
 		int index = it - split_msg.begin();
@@ -59,6 +49,7 @@ std::string	setClientUsername(std::string message, std::vector<std::string> spli
 				if (it->compare("0") != 0)
 				{
 					std::cout << "Invalid mode " << *it << std::endl;
+					client.setUsername("");					
 					return (ERR_INVALIDMODE);
 				}
 				break ;
@@ -66,12 +57,16 @@ std::string	setClientUsername(std::string message, std::vector<std::string> spli
 				if (it->compare("*") != 0)
 				{
 					std::cout << "This unused " << *it << " is invalid" << std::endl;	
+					client.setUsername("");					
 					return (ERR_INVALIDUNUSED);
 				}
 				break ;
+			case 4:
+				if (!parseRealName(*it, client))
+					return (ERR_INVALIDREALNAME);
+				else
+					client.setRealname(*it);
 		}
 	}
-	if (!fetchRealName(message, client))
-		return (ERR_INVALIDREALNAME);
 	return (RPL_SUCCESS);
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -127,14 +127,25 @@ void Server::handleNewConnection()
 	}
 }
 
-std::vector<std::string> split(const std::string message)
+std::vector<std::string> split(std::string message)
 {
-	std::vector<std::string> res;
-	std::istringstream iss(message);
-	std::string word;
+	std::vector<std::string>	res;
+	std::string::size_type		trailing_pos;
+	std::istringstream			iss;
+	std::string					word;
+	std::string					trailing;
 
+	trailing_pos = message.find_first_of(':');
+	if (trailing_pos != std::string::npos && trailing_pos > 1 && message.at(trailing_pos - 1) == ' ')
+	{
+		trailing = message.substr(trailing_pos + 1, message.size() - trailing_pos);
+		message.resize(trailing_pos);
+	}
+	iss.str(message);
 	while (iss >> word)
 		res.push_back(word);
+	if (!trailing.empty())
+		res.push_back(trailing);
 	return (res);
 }
 
@@ -146,7 +157,7 @@ void Server::processClientBuffer(Client &client)
 	while ((pos = buf.find("\r\n")) != std::string::npos)
 	{
 		std::string message = buf.substr(0, pos);
-		buf.erase(0, pos + 1);
+		buf.erase(0, pos + 2);
 		std::vector<std::string> split_msg = split(message);
 		std::cout << "Received command: " << message << std::endl;
 		if (!split_msg.empty())
@@ -412,19 +423,11 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
 
-	res = manageChannelMode(
-			chanIt->second, 
-			modes, 
-			params, 
-			_clients, 
-			chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
+	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
 
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 	{
-		sendMessage(
-				client.getFd(),
-				":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName()
-				+ " " + showChannelModes(chanIt->second));
+		sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " + showChannelModes(chanIt->second));
 		return;
 	}
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
@@ -438,17 +441,14 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		return;
 	}
 	if (!modeChange.empty())
-		broadcastToChannel(
-				chanIt->second.getName(), 
-				":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " 
-				+ chanIt->second.getName() + " " + modeChange, client.getFd());
+		broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
 void Server::handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::map<std::string, Channel>::iterator	chanIt;
-	std::map<int, Client>::iterator				targetIt;
-	std::string									res;
+	std::map<std::string, Channel>::iterator chanIt;
+	std::map<int, Client>::iterator targetIt;
+	std::string res;
 
 	(void)rawMsg;
 	if (tokens.size() < 3)
@@ -474,17 +474,8 @@ void Server::handleInvite(Client &client, const std::string &rawMsg, const std::
 		sendError(client, "INVITE", res);
 		return;
 	}
-	sendMessage(
-		client.getFd(), 
-			":" + _serverName
-			+ " " + res
-			+ " " + client.getNickname() 
-			+ " " + targetIt->second.getNickname()
-			+ " " + chanIt->second.getName());
-	sendMessage(
-			targetIt->second.getFd(),
-			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost()
-			+ " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + res + " " + client.getNickname() + " " + targetIt->second.getNickname() + " " + chanIt->second.getName());
+	sendMessage(targetIt->second.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -267,13 +267,14 @@ void Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 void Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::string res;
-
+	
+	(void)rawMsg;
 	if (tokens.size() < 5)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + MSG_NEEDMOREPARAMS);
 		return;
 	}
-	res = setClientUsername(rawMsg, tokens, client);
+	res = setClientUsername(tokens, client);
 	if (!res.empty() && res.compare(RPL_SUCCESS) != 0)
 		sendError(client, "USER", res);
 }
@@ -375,27 +376,22 @@ void Server::handleCap(Client &client, const std::string &rawMsg, const std::vec
 
 void Server::handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PING " + MSG_NEEDMOREPARAMS);
 		return;
 	}
-	size_t pos = rawMsg.find_first_of(":");
-	if (pos != std::string::npos)
-		sendMessage(client.getFd(), "PONG " + rawMsg.substr(pos));
-	else
+	std::string msg;
+	std::vector<std::string>::const_iterator last = tokens.end();
+	++last;
+	for (std::vector<std::string>::const_iterator it = tokens.begin() + 1; it != tokens.end(); ++it)
 	{
-		std::string msg;
-		std::vector<std::string>::const_iterator last = tokens.end();
-		last++;
-		for (std::vector<std::string>::const_iterator it = tokens.begin() + 1; it != tokens.end(); ++it)
-		{
-			msg.append(*it);
-			if (it != last)
-				msg.append(" ");
-		}
-		sendMessage(client.getFd(), "PONG " + msg);
+		msg.append(*it);
+		if (it != last)
+			msg.append(" ");
 	}
+	sendMessage(client.getFd(), "PONG " + msg);
 }
 
 void Server::handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)


### PR DESCRIPTION
## Closes #54

### Summary

This branch fixes the handling of the trailing `:` separator in IRC message parsing. Previously, the `split()` function did not account for the IRC protocol's trailing parameter convention (a `:` prefix denoting the last, potentially space-containing parameter), which broke commands like `USER` (real name with spaces) and `PING` (messages with spaces).

### Changes

**`src/server/Server.cpp` — `split()` function (core fix):**
- The `split()` function now detects the trailing `:` separator. When found, everything after the `:` is preserved as a single token (instead of being split on spaces), conforming to the IRC protocol specification.
- Buffer erase offset fixed: `pos + 1` → `pos + 2` to correctly skip the `\r\n` two-character sequence.

**`src/commands/USER.cpp`:**
- Removed the manual `fetchRealName()` function that was redundantly re-parsing the raw message for the real name using `find_first_of(':')`. The real name is now correctly extracted from the already-split `tokens` vector (index 4), since the `split()` fix properly preserves trailing parameters.
- `setClientUsername()` signature simplified: removed the unused `message` parameter since raw message parsing is no longer needed.
- Added `client.setUsername("")` on invalid mode / unused parameter errors to avoid leaving the username in a partial state.
- Code formatting cleaned up in `handleMode` and `handleInvite` (collapsed multi-line expressions).

**`includes/utils/Utils.hpp`:**
- Updated `setClientUsername` declaration to match the new signature.

**`src/server/Server.cpp` — `handlePing()`:**
- Simplified `PING` handling to always iterate over tokens instead of manually searching the raw message for `:`, since the `split()` function now preserves the trailing content as a single token.

**`src/server/Server.cpp` — `handleUser()`:**
- Adapted to pass only `tokens` (not the raw message) to `setClientUsername`.

### Additional fixes included

- Bug fix in `USER` command: username is now properly cleared on validation errors (invalid mode or unused field), preventing inconsistent client state.