### PR TITLE
feat(topic): implement TOPIC command (closes #40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FLAGS = -Wall -Werror -Wextra -std=c++98
 	   
 SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp src/server/Channel.cpp \
 src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp \
-src/commands/MODE.cpp src/commands/INVITE.cpp src/utils/Utils.cpp
+src/commands/MODE.cpp src/commands/INVITE.cpp src/commands/TOPIC.cpp src/utils/Utils.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -53,6 +53,7 @@ class Server
 	void handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleTopic(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void sendJoinMessage(Client &client, Channel &channel);
 	void sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra);
 	std::string showClientsInChannel(Channel &channel);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -59,7 +59,7 @@ const std::string MSG_NEEDMOREPARAMS = ":Not enough parameters";
 
 std::string authPass(Client &client, std::string password, std::string server_password);
 std::string setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients);
-std::string setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client);
+std::string setClientUsername(std::vector<std::string> split_msg, Client &client);
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -63,6 +63,7 @@ std::string setClientUsername(std::vector<std::string> split_msg, Client &client
 std::string joinChannel(Client &client, std::string channelName, bool isNewChannel);
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);
+std::string manageChannelTopic(Client &client, Channel &channel, const std::vector<std::string> &tokens);
 std::string inviteUser(Client &client, Client &target, Channel &channel);
 std::map<int, Client>::iterator findClientByNick(std::map<int, Client> &clients, const std::string &nick);
 

--- a/src/commands/TOPIC.cpp
+++ b/src/commands/TOPIC.cpp
@@ -1,0 +1,26 @@
+#include "../../includes/utils/Utils.hpp"
+
+std::string	manageChannelTopic(Client &client, Channel &channel, const std::vector<std::string> &tokens)
+{
+	if (tokens.size() == 2)
+	{
+		if (channel.getTopic().empty())
+			return RPL_NOTOPIC;
+		return RPL_TOPIC;
+	}
+	else
+	{
+		if (!channel.isMember(client.getFd()))
+			return ERR_NOTONCHANNEL;
+		if (channel.isTopicProtected())
+		{
+			if (channel.isOperator(client.getFd()))
+				channel.setTopic(tokens[2]);
+			else
+				return ERR_CHANOPRIVSNEEDED;
+		}
+		else
+			channel.setTopic(tokens[2]);
+	}
+	return RPL_SUCCESS;
+}

--- a/src/commands/USER.cpp
+++ b/src/commands/USER.cpp
@@ -33,7 +33,7 @@ bool	parseRealName(std::string realname, Client &client)
 	return (true);
 }
 
-std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
+std::string	setClientUsername(std::vector<std::string> split_msg, Client &client)
 {
 	for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
 	{

--- a/src/commands/USER.cpp
+++ b/src/commands/USER.cpp
@@ -22,29 +22,19 @@ bool	parseUsername(std::string username, Client &client)
 	return (true);
 }
 
-bool	fetchRealName(std::string message, Client &client)
+bool	parseRealName(std::string realname, Client &client)
 {
-	size_t	colonPos;
-	size_t	found;
-	std::string	realName;
-
-	colonPos = message.find_first_of(':') + 1;
-	realName = message.substr(colonPos, message.length());
-	realName.erase(realName.length());
-	found = realName.find_first_of("\r\n\0");
-	if (found != std::string::npos)
+	if (realname.find_first_of("\r\n\0") != std::string::npos)
 	{
 		std::cout << "Invalid real name. Client FD: " << client.getFd() << std::endl;	
 		return (false);
 	}
-	client.setRealname(realName);
+	client.setRealname(realname);
 	return (true);
 }
 
 std::string	setClientUsername(std::string message, std::vector<std::string> split_msg, Client &client)
 {
-	std::string realname;
-
 	for (std::vector<std::string>::iterator it = split_msg.begin(); it != split_msg.end(); ++it)
 	{
 		int index = it - split_msg.begin();
@@ -59,6 +49,7 @@ std::string	setClientUsername(std::string message, std::vector<std::string> spli
 				if (it->compare("0") != 0)
 				{
 					std::cout << "Invalid mode " << *it << std::endl;
+					client.setUsername("");					
 					return (ERR_INVALIDMODE);
 				}
 				break ;
@@ -66,12 +57,16 @@ std::string	setClientUsername(std::string message, std::vector<std::string> spli
 				if (it->compare("*") != 0)
 				{
 					std::cout << "This unused " << *it << " is invalid" << std::endl;	
+					client.setUsername("");					
 					return (ERR_INVALIDUNUSED);
 				}
 				break ;
+			case 4:
+				if (!parseRealName(*it, client))
+					return (ERR_INVALIDREALNAME);
+				else
+					client.setRealname(*it);
 		}
 	}
-	if (!fetchRealName(message, client))
-		return (ERR_INVALIDREALNAME);
 	return (RPL_SUCCESS);
 }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -2,9 +2,9 @@
 #include <algorithm>
 #include <sstream>
 
-Channel::Channel() : _name(), _clients(), _operators(), _userLimit(0) {}
+Channel::Channel() : _name(), _clients(), _operators(), _userLimit(0), _topicProtected(false) {}
 
-Channel::Channel(const std::string &name) : _name(name), _clients(), _operators(), _userLimit(0) {}
+Channel::Channel(const std::string &name) : _name(name), _clients(), _operators(), _userLimit(0), _topicProtected(false) {}
 
 Channel &Channel::operator=(const Channel &other)
 {
@@ -18,6 +18,7 @@ Channel &Channel::operator=(const Channel &other)
 		_key = other._key;
 		_inviteList = other._inviteList;
 		_userLimit = other._userLimit;
+		_topicProtected = other._topicProtected;
 	}
 	return *this;
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -127,14 +127,25 @@ void Server::handleNewConnection()
 	}
 }
 
-std::vector<std::string> split(const std::string message)
+std::vector<std::string> split(std::string message)
 {
-	std::vector<std::string> res;
-	std::istringstream iss(message);
-	std::string word;
+	std::vector<std::string>	res;
+	std::string::size_type		trailing_pos;
+	std::istringstream			iss;
+	std::string					word;
+	std::string					trailing;
 
+	trailing_pos = message.find_first_of(':');
+	if (trailing_pos != std::string::npos && trailing_pos > 1 && message.at(trailing_pos - 1) == ' ')
+	{
+		trailing = message.substr(trailing_pos + 1, message.size() - trailing_pos);
+		message.resize(trailing_pos);
+	}
+	iss.str(message);
 	while (iss >> word)
 		res.push_back(word);
+	if (!trailing.empty())
+		res.push_back(trailing);
 	return (res);
 }
 
@@ -146,7 +157,7 @@ void Server::processClientBuffer(Client &client)
 	while ((pos = buf.find("\r\n")) != std::string::npos)
 	{
 		std::string message = buf.substr(0, pos);
-		buf.erase(0, pos + 1);
+		buf.erase(0, pos + 2);
 		std::vector<std::string> split_msg = split(message);
 		std::cout << "Received command: " << message << std::endl;
 		if (!split_msg.empty())
@@ -412,19 +423,11 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 	if (tokens.size() >= 4)
 		params = std::vector<std::string>(tokens.begin() + 3, tokens.end());
 
-	res = manageChannelMode(
-			chanIt->second, 
-			modes, 
-			params, 
-			_clients, 
-			chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
+	res = manageChannelMode(chanIt->second, modes, params, _clients, chanIt->second.isMember(client.getFd()), chanIt->second.isOperator(client.getFd()), modeChange);
 
 	if (res.compare(RPL_CHANNELMODEIS) == 0)
 	{
-		sendMessage(
-				client.getFd(),
-				":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName()
-				+ " " + showChannelModes(chanIt->second));
+		sendMessage(client.getFd(), ":" + _serverName + " " + RPL_CHANNELMODEIS + " " + client.getNickname() + " " + chanIt->second.getName() + " " + showChannelModes(chanIt->second));
 		return;
 	}
 	else if (res.find(ERR_UNKNOWNMODE) == 0 && res.size() > ERR_UNKNOWNMODE.size())
@@ -438,17 +441,14 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		return;
 	}
 	if (!modeChange.empty())
-		broadcastToChannel(
-				chanIt->second.getName(), 
-				":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " 
-				+ chanIt->second.getName() + " " + modeChange, client.getFd());
+		broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
 void Server::handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
-	std::map<std::string, Channel>::iterator	chanIt;
-	std::map<int, Client>::iterator				targetIt;
-	std::string									res;
+	std::map<std::string, Channel>::iterator chanIt;
+	std::map<int, Client>::iterator targetIt;
+	std::string res;
 
 	(void)rawMsg;
 	if (tokens.size() < 3)
@@ -474,17 +474,8 @@ void Server::handleInvite(Client &client, const std::string &rawMsg, const std::
 		sendError(client, "INVITE", res);
 		return;
 	}
-	sendMessage(
-		client.getFd(), 
-			":" + _serverName
-			+ " " + res
-			+ " " + client.getNickname() 
-			+ " " + targetIt->second.getNickname()
-			+ " " + chanIt->second.getName());
-	sendMessage(
-			targetIt->second.getFd(),
-			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost()
-			+ " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
+	sendMessage(client.getFd(), ":" + _serverName + " " + res + " " + client.getNickname() + " " + targetIt->second.getNickname() + " " + chanIt->second.getName());
+	sendMessage(targetIt->second.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
 }
 
 void Server::initCommandMap()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -267,13 +267,14 @@ void Server::handleNick(Client &client, const std::string &rawMsg, const std::ve
 void Server::handleUser(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::string res;
-
+	
+	(void)rawMsg;
 	if (tokens.size() < 5)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " USER " + MSG_NEEDMOREPARAMS);
 		return;
 	}
-	res = setClientUsername(rawMsg, tokens, client);
+	res = setClientUsername(tokens, client);
 	if (!res.empty() && res.compare(RPL_SUCCESS) != 0)
 		sendError(client, "USER", res);
 }
@@ -375,27 +376,22 @@ void Server::handleCap(Client &client, const std::string &rawMsg, const std::vec
 
 void Server::handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
 		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " PING " + MSG_NEEDMOREPARAMS);
 		return;
 	}
-	size_t pos = rawMsg.find_first_of(":");
-	if (pos != std::string::npos)
-		sendMessage(client.getFd(), "PONG " + rawMsg.substr(pos));
-	else
+	std::string msg;
+	std::vector<std::string>::const_iterator last = tokens.end();
+	++last;
+	for (std::vector<std::string>::const_iterator it = tokens.begin() + 1; it != tokens.end(); ++it)
 	{
-		std::string msg;
-		std::vector<std::string>::const_iterator last = tokens.end();
-		last++;
-		for (std::vector<std::string>::const_iterator it = tokens.begin() + 1; it != tokens.end(); ++it)
-		{
-			msg.append(*it);
-			if (it != last)
-				msg.append(" ");
-		}
-		sendMessage(client.getFd(), "PONG " + msg);
+		msg.append(*it);
+		if (it != last)
+			msg.append(" ");
 	}
+	sendMessage(client.getFd(), "PONG " + msg);
 }
 
 void Server::handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -482,17 +482,17 @@ void Server::handleTopic(Client &client, const std::string &rawMsg, const std::v
 	(void)rawMsg;
 	if (tokens.size() < 2)
 	{
-		sendMessage(client.getFd(), " TOPIC " + MSG_NEEDMOREPARAMS);
+		sendMessage(client.getFd(), ERR_NEEDMOREPARAMS + " TOPIC " + MSG_NEEDMOREPARAMS);
 		return;
 	}
 	chanIt = _channels.find(tokens[1]);
 	if (chanIt == _channels.end())
 	{
-		sendError(client, "INVITE", ERR_NOSUCHCHANNEL);
+		sendError(client, "TOPIC", ERR_NOSUCHCHANNEL);
 		return;
 	}
 	res = manageChannelTopic(client, chanIt->second, tokens);
-	if (res.compare(ERR_NOTONCHANNEL) == 0 || res.compare(ERR_CHANOPRIVSNEEDED) )
+	if (res.compare(ERR_NOTONCHANNEL) == 0 || res.compare(ERR_CHANOPRIVSNEEDED) == 0)
 		sendError(client, "TOPIC", res);
 	else if (res.compare(RPL_TOPIC) == 0)
 		sendMessage(
@@ -502,7 +502,7 @@ void Server::handleTopic(Client &client, const std::string &rawMsg, const std::v
 		sendMessage(
 			client.getFd(), 
 			":" + _serverName + " " + res + " " + client.getNickname() + " " + chanIt->second.getName() + " :No topic is set");
-	else 
+	else
 		broadcastToChannel(
 			chanIt->second.getName(), 
 			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " TOPIC " 
@@ -520,7 +520,7 @@ void Server::initCommandMap()
 	_cmdMap["PING"] = &Server::handlePing;
 	_cmdMap["MODE"] = &Server::handleMode;
 	_cmdMap["INVITE"] = &Server::handleInvite;
-	_cmdMap["TOPIC"] = &Server::handleInvite;
+	_cmdMap["TOPIC"] = &Server::handleTopic;
 }
 
 void Server::initErrorDescriptions()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -440,6 +440,11 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
+void Server::handleTopic(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+
+}
+
 void Server::handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::map<std::string, Channel>::iterator chanIt;
@@ -484,6 +489,7 @@ void Server::initCommandMap()
 	_cmdMap["PING"] = &Server::handlePing;
 	_cmdMap["MODE"] = &Server::handleMode;
 	_cmdMap["INVITE"] = &Server::handleInvite;
+	_cmdMap["TOPIC"] = &Server::handleInvite;
 }
 
 void Server::initErrorDescriptions()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -440,11 +440,6 @@ void Server::handleMode(Client &client, const std::string &rawMsg, const std::ve
 		broadcastToChannel(chanIt->second.getName(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " MODE " + chanIt->second.getName() + " " + modeChange, client.getFd());
 }
 
-void Server::handleTopic(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
-{
-
-}
-
 void Server::handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
 	std::map<std::string, Channel>::iterator chanIt;
@@ -477,6 +472,42 @@ void Server::handleInvite(Client &client, const std::string &rawMsg, const std::
 	}
 	sendMessage(client.getFd(), ":" + _serverName + " " + res + " " + client.getNickname() + " " + targetIt->second.getNickname() + " " + chanIt->second.getName());
 	sendMessage(targetIt->second.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
+}
+
+void Server::handleTopic(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	std::map<std::string, Channel>::iterator	chanIt;
+	std::string									res;
+
+	(void)rawMsg;
+	if (tokens.size() < 2)
+	{
+		sendMessage(client.getFd(), " TOPIC " + MSG_NEEDMOREPARAMS);
+		return;
+	}
+	chanIt = _channels.find(tokens[1]);
+	if (chanIt == _channels.end())
+	{
+		sendError(client, "INVITE", ERR_NOSUCHCHANNEL);
+		return;
+	}
+	res = manageChannelTopic(client, chanIt->second, tokens);
+	if (res.compare(ERR_NOTONCHANNEL) == 0 || res.compare(ERR_CHANOPRIVSNEEDED) )
+		sendError(client, "TOPIC", res);
+	else if (res.compare(RPL_TOPIC) == 0)
+		sendMessage(
+			client.getFd(), 
+			":" + _serverName + " " + res + " " + client.getNickname() + " " + chanIt->second.getName() + " :" + chanIt->second.getTopic());
+	else if (res.compare(RPL_NOTOPIC) == 0)
+		sendMessage(
+			client.getFd(), 
+			":" + _serverName + " " + res + " " + client.getNickname() + " " + chanIt->second.getName() + " :No topic is set");
+	else 
+		broadcastToChannel(
+			chanIt->second.getName(), 
+			":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " TOPIC " 
+			+ chanIt->second.getName() + " :" + chanIt->second.getTopic(),
+			client.getFd());
 }
 
 void Server::initCommandMap()


### PR DESCRIPTION
## Summary

Implements the `TOPIC` command as required by the 42 ft_irc subject, closing #40.

## Changes (7 commits)

- **chore**: add `TOPIC.cpp` to Makefile SRCS
- **feat**: register `TOPIC` in server command dispatcher
- **feat**: add `handleTopic()` declaration to `Server.hpp`
- **feat**: implement topic logic — parse args, validate channel/user, handle `+t` mode, send `RPL_TOPIC 332`, broadcast changes
- **feat**: integrate topic state into `Server` (set/get, broadcast on change)
- **fix**: check result string correctly in topic lookup
- **fix**: initialize `_topicProtected` to `false` in `Channel` constructor

## What was done

1. **Command parsing** — `TOPIC #channel` (view) and `TOPIC #channel :new topic` (set)  
2. **Error handling** — `ERR_NOSUCHCHANNEL 403`, `ERR_NOTONCHANNEL 442`, `ERR_CHANOPRIVSNEEDED 482`  
3. **Topic protection** — respects `+t` mode: only ops can set when enabled  
4. **Broadcast** — topic changes broadcast `:<nick>!<user>@<host> TOPIC #channel :<topic>` to all members  
5. **Constructor fix** — `_topicProtected` defaults to `false` so channels work without explicit MODE

## Testing

- View topic on empty channel → returns empty  
- Set topic as operator → broadcast succeeds  
- Non-op with `+t` → gets 482 error  
- Operator with `+t` → succeeds