### PR TITLE
fix(nick): remove debug output and fix same-nick-in-use check

### DIFF
--- a/src/commands/NICK.cpp
+++ b/src/commands/NICK.cpp
@@ -10,12 +10,11 @@ bool	isSpecial(char c)
 	return (false);
 }
 
-bool	isNewNick(std::map<int, Client> &clients, std::string nickname)
+bool	isNewNick(Client &client, std::map<int, Client> &clients, std::string nickname)
 {
 	for (std::map<int, Client>::iterator it = clients.begin(); it != clients.end(); ++it)
 	{
-		Client client = it->second;
-		if (client.getNickname().compare(nickname) == 0)
+		if (it->second.getNickname().compare(nickname) == 0 && it->second.getFd() != client.getFd())
 			return (false);
 	}
 	return (true);
@@ -24,29 +23,15 @@ bool	isNewNick(std::map<int, Client> &clients, std::string nickname)
 std::string	setClientNick(std::string nickname, Client &client, std::map<int, Client> &clients)
 {
 	if (nickname.length() < 1 || nickname.length() > 9)
-	{
-		std::cout << "Ivalid nick: nickname must be between 1 and 9. Client FD: " << client.getFd() << std::endl;
 		return (ERR_ERRONEUSNICKNAME);
-	}
 	if (!std::isalpha(nickname[0]) && !isSpecial(nickname[0]))
-	{
-		std::cout << "Ivalid nick: first character must be alpha or special. Client FD: " << client.getFd() << std::endl;
 		return (ERR_ERRONEUSNICKNAME);
-	}
-	if (!isNewNick(clients, nickname))
-	{
-		std::cout << "Nick " << nickname << " has already been registered. Client FD: " << client.getFd() << std::endl;
+	if (!isNewNick(client, clients, nickname))
 		return (ERR_NICKNAMEINUSE);
-	}
 	for (std::string::iterator it = nickname.begin(); it != nickname.end(); ++it)
-	{
 		if (!std::isalpha(*it) && !std::isdigit(*it) && !isSpecial(*it))
-		{
-			std::cout << "Ivalid nick: invalid character: " << *it << ". Client FD: " << client.getFd() << std::endl;
 			return (ERR_ERRONEUSNICKNAME);
-		}
-	}
-	client.setNickname(nickname);
-	std::cout << "nick set: " << client.getNickname() << std::endl;
+	if (client.getNickname().compare(nickname) != 0)
+		client.setNickname(nickname);
 	return (RPL_SUCCESS);
 }


### PR DESCRIPTION
Remove std::cout debug message from NICK command.

Fix: sending NICK with same nick as current no longer sends ERR_NICKNAMEINUSE. Only triggers when another client already owns the nick.