### PR TITLE
fix(join): prevent duplicate channel join

### DIFF
--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -338,6 +338,8 @@ void Server::handleJoin(Client &client, const std::string &rawMsg, const std::ve
 	}
 
 	Channel &channel = it->second;
+	if (!isNew && channel.getClients().find(client.getFd()) != channel.getClients().end())
+		return;
 	if (tokens.size() >= 3)
 		isKeyPass = channel.getKey().compare(tokens[2]) == 0;
 


### PR DESCRIPTION
Fixes #52

Add check in `handleJoin` to silently ignore if client is already on the channel, per RFC 2812.

**Changed:** `src/server/Server.cpp` (+2 lines)