### PR TITLE
feat(kick): implement KICK command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FLAGS = -Wall -Werror -Wextra -std=c++98
 	   
 SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp src/server/Channel.cpp \
 src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp \
-src/commands/MODE.cpp src/commands/INVITE.cpp src/utils/Utils.cpp
+src/commands/MODE.cpp src/commands/INVITE.cpp src/commands/KICK.cpp src/utils/Utils.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -52,6 +52,7 @@ class Server
 	void handleCap(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handlePing(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handleKick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void sendJoinMessage(Client &client, Channel &channel);
 	void sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -64,6 +64,7 @@ std::string joinChannel(Client &client, std::string channelName, bool isNewChann
 std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);
 std::string inviteUser(Client &client, Client &target, Channel &channel);
+std::string	manangeKickCommand(Client &client, Channel &channel, Client &target);
 std::map<int, Client>::iterator findClientByNick(std::map<int, Client> &clients, const std::string &nick);
 
 #endif

--- a/src/commands/KICK.cpp
+++ b/src/commands/KICK.cpp
@@ -1,0 +1,12 @@
+#include "../../includes/utils/Utils.hpp"
+
+std::string	manangeKickCommand(Client &client, Channel &channel, Client &target)
+{
+	if (!channel.isMember(client.getFd()))
+		return ERR_NOTONCHANNEL;
+	if (!channel.isOperator(client.getFd()))
+		return ERR_CHANOPRIVSNEEDED;
+	if (!channel.isMember(target.getFd()))
+		return ERR_USERNOTINCHANNEL;
+	return RPL_SUCCESS;
+}

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -474,6 +474,11 @@ void Server::handleInvite(Client &client, const std::string &rawMsg, const std::
 	sendMessage(targetIt->second.getFd(), ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost() + " " + "INVITE " + targetIt->second.getNickname() + " :" + chanIt->second.getName());
 }
 
+void Server::handleKick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+
+}
+
 void Server::initCommandMap()
 {
 	_cmdMap["PASS"] = &Server::handlePass;
@@ -484,6 +489,7 @@ void Server::initCommandMap()
 	_cmdMap["PING"] = &Server::handlePing;
 	_cmdMap["MODE"] = &Server::handleMode;
 	_cmdMap["INVITE"] = &Server::handleInvite;
+	_cmdMap["KICK"] = &Server::handleKick;
 }
 
 void Server::initErrorDescriptions()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -476,7 +476,43 @@ void Server::handleInvite(Client &client, const std::string &rawMsg, const std::
 
 void Server::handleKick(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
 {
+	std::map<std::string, Channel>::iterator	chanIt;
+	std::map<int, Client>::iterator				targetIt;
+	std::string									res;
 
+	(void)rawMsg;
+	if (tokens.size() < 3)
+	{
+		sendError(client, "KICK", ERR_NEEDMOREPARAMS);
+		return;
+	}
+	chanIt = _channels.find(tokens[1]);
+	targetIt = findClientByNick(_clients, tokens[2]);
+	if (chanIt == _channels.end())
+	{
+		sendError(client, "KICK", ERR_NOSUCHCHANNEL);
+		return;
+	}
+	if (targetIt == _clients.end())
+	{
+		sendError(client, "KICK", ERR_NOSUCHNICK);
+		return;
+	}
+	res = manangeKickCommand(client, chanIt->second, targetIt->second);
+	if (res.compare(RPL_SUCCESS) != 0)
+	{
+		sendError(client, "KICK", res);
+		return;
+	}
+	broadcastToChannel(
+		chanIt->second.getName(), 
+		":" + client.getNickname() + "!" +  client.getUsername() + "@" + client.getHost() + " KICK " 
+		+ chanIt->second.getName() + " " + targetIt->second.getNickname()
+		+ ((tokens.size() > 3) ? (" :" + tokens[3]) : ""),
+		0);
+	if (chanIt->second.isOperator(targetIt->second.getFd()))
+		chanIt->second.removeOperator(targetIt->second.getFd());
+	chanIt->second.removeClient(targetIt->second.getFd());
 }
 
 void Server::initCommandMap()


### PR DESCRIPTION
Closes #36

Implements the KICK command allowing channel operators to remove users from channels.

`broadcastToChannel` is called with `excludeFd` set to `0` so that the operator who executed the kick command also receives the broadcast message.

Kicking multiple clients in a single command is not implemented, as the project scope does not require it.