### PR TITLE
feat(part): implement PART command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ FLAGS = -Wall -Werror -Wextra -std=c++98
 	   
 SRCS = src/general/main.cpp src/server/Server.cpp src/client/Client.cpp src/server/Channel.cpp \
 src/commands/PASS.cpp src/commands/NICK.cpp src/commands/USER.cpp src/commands/JOIN.cpp \
-src/commands/MODE.cpp src/commands/INVITE.cpp src/commands/TOPIC.cpp src/utils/Utils.cpp
+src/commands/MODE.cpp src/commands/INVITE.cpp src/commands/TOPIC.cpp src/commands/PART.cpp \
+src/utils/Utils.cpp
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/includes/server/Server.hpp
+++ b/includes/server/Server.hpp
@@ -54,6 +54,7 @@ class Server
 	void handleMode(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleInvite(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void handleTopic(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
+	void handlePart(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens);
 	void sendJoinMessage(Client &client, Channel &channel);
 	void sendError(Client &client, const std::string &command, const std::string &errorCode, const std::string &extra);
 	std::string showClientsInChannel(Channel &channel);

--- a/includes/utils/Utils.hpp
+++ b/includes/utils/Utils.hpp
@@ -65,6 +65,7 @@ std::string checkChannelMode(Channel &channel, int clientFd, bool isKeyPass);
 std::string manageChannelMode(Channel &channel, std::string modes, std::vector<std::string> &params, std::map<int, Client> &clients, bool isMember, bool isOperator, std::string &modeChange);
 std::string manageChannelTopic(Client &client, Channel &channel, const std::vector<std::string> &tokens);
 std::string inviteUser(Client &client, Client &target, Channel &channel);
+std::string	managePartCommand(Client &client, Channel &channel);
 std::map<int, Client>::iterator findClientByNick(std::map<int, Client> &clients, const std::string &nick);
 
 #endif

--- a/src/commands/PART.cpp
+++ b/src/commands/PART.cpp
@@ -1,0 +1,9 @@
+#include "../../includes/utils/Utils.hpp"
+
+std::string	managePartCommand(Client &client, Channel &channel)
+{
+	if (!channel.isMember(client.getFd()))
+		return ERR_NOTONCHANNEL;
+	return RPL_SUCCESS;
+}
+

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -512,6 +512,38 @@ void Server::handleTopic(Client &client, const std::string &rawMsg, const std::v
 			client.getFd());
 }
 
+void Server::handlePart(Client &client, const std::string &rawMsg, const std::vector<std::string> &tokens)
+{
+	std::map<std::string, Channel>::iterator	chanIt;
+	std::string									res;
+
+	(void)rawMsg;
+	if (tokens.size() < 2)
+	{
+		sendError(client, "PART", ERR_NEEDMOREPARAMS);
+		return;
+	}
+	chanIt = _channels.find(tokens[1]);
+	if (chanIt == _channels.end())
+	{
+		sendError(client, "PART", ERR_NOSUCHCHANNEL);
+		return;
+	}
+	res = managePartCommand(client, chanIt->second);
+	if (res.compare(ERR_NOTONCHANNEL) == 0)
+	{
+		sendError(client, "PART", res);
+	}
+	else 
+	{
+		if (chanIt->second.isOperator(client.getFd()))
+			chanIt->second.removeOperator(client.getFd());
+		chanIt->second.removeClient(client.getFd());
+		if (chanIt->second.getClients().empty())
+			_channels.erase(chanIt->first);	
+	}
+}
+
 void Server::initCommandMap()
 {
 	_cmdMap["PASS"] = &Server::handlePass;
@@ -523,6 +555,7 @@ void Server::initCommandMap()
 	_cmdMap["MODE"] = &Server::handleMode;
 	_cmdMap["INVITE"] = &Server::handleInvite;
 	_cmdMap["TOPIC"] = &Server::handleTopic;
+	_cmdMap["PART"] = &Server::handlePart;
 }
 
 void Server::initErrorDescriptions()

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -531,12 +531,16 @@ void Server::handlePart(Client &client, const std::string &rawMsg, const std::ve
 	}
 	res = managePartCommand(client, chanIt->second);
 	if (res.compare(ERR_NOTONCHANNEL) == 0)
-	{
 		sendError(client, "PART", res);
-	}
 	else 
 	{
-		if (chanIt->second.isOperator(client.getFd()))
+    broadcastToChannel(
+        chanIt->second.getName(),
+        ":" + client.getNickname() + "!" + client.getUsername() + "@" + client.getHost()
+        + " PART " + chanIt->second.getName()
+        + ((tokens.size() > 2) ? (" :" + tokens[2]) : ""),
+        0);
+	  if (chanIt->second.isOperator(client.getFd()))
 			chanIt->second.removeOperator(client.getFd());
 		chanIt->second.removeClient(client.getFd());
 		if (chanIt->second.getClients().empty())


### PR DESCRIPTION
## Summary

Implements the PART command allowing users to voluntarily leave channels, resolving #37.

## Changes

- Added `PART.cpp` command handler with full IRC protocol compliance
- Parse `PART #channel` and `PART #channel :reason` syntax
- Validate channel exists (`ERR_NOSUCHCHANNEL 403`)
- Validate user is on channel (`ERR_NOTONCHANNEL 442`)
- Remove user from channel members and operators list
- Clean up empty channels from `_channels` map
- Broadcast `:<nick>!<user>@<host> PART #channel [:reason]` to all members

## Technical Note

The `broadcastToChannel` function uses `0` as the ignore fd parameter because the PART message should be broadcast to **all** members of the channel, including the client executing the PART command. This ensures the departing user receives confirmation of their leave.

## Out of Scope

Leaving multiple channels in a single PART command (e.g., `PART #ch1,#ch2`) is not implemented as it falls outside the project scope defined by the 42 ft_irc subject.

## Testing

- [ ] Code compiles with `-Wall -Wextra -Werror`
- [ ] Manual test: user can leave channel and is removed from member list
- [ ] Manual test: empty channels are cleaned up
- [ ] Manual test: other members see the PART notification
- [ ] Manual test: optional reason/message is included